### PR TITLE
Server, Executor: Fixed bugs and modified unit tests

### DIFF
--- a/executor/builder.go
+++ b/executor/builder.go
@@ -23,14 +23,14 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/cznic/mathutil"
-	"github.com/cznic/sortutil"
-	"github.com/pingcap/errors"
-	"github.com/pingcap/kvproto/pkg/diagnosticspb"
 	"github.com/DigitalChinaOpenSource/DCParser/ast"
 	"github.com/DigitalChinaOpenSource/DCParser/auth"
 	"github.com/DigitalChinaOpenSource/DCParser/model"
 	"github.com/DigitalChinaOpenSource/DCParser/mysql"
+	"github.com/cznic/mathutil"
+	"github.com/cznic/sortutil"
+	"github.com/pingcap/errors"
+	"github.com/pingcap/kvproto/pkg/diagnosticspb"
 	"github.com/pingcap/tidb/distsql"
 	"github.com/pingcap/tidb/domain"
 	"github.com/pingcap/tidb/executor/aggfuncs"
@@ -1470,7 +1470,8 @@ func (b *executorBuilder) buildMemTable(v *plannercore.PhysicalMemTable) Executo
 					columns: v.Columns,
 				},
 			}
-		case strings.ToLower(infoschema.TableColumns):
+		case strings.ToLower(infoschema.TableColumns),
+			strings.ToLower(infoschema.TablePgColumns):
 			return &MemTableReaderExec{
 				baseExecutor: newBaseExecutor(b.ctx, v.Schema(), v.ID()),
 				table:        v.Table,
@@ -1514,6 +1515,22 @@ func (b *executorBuilder) buildMemTable(v *plannercore.PhysicalMemTable) Executo
 					table:      v.Table,
 					outputCols: v.Columns,
 					extractor:  v.Extractor.(*plannercore.TiFlashSystemTableExtractor),
+				},
+			}
+		case strings.ToLower(infoschema.TablePgSchemata),
+			strings.ToLower(infoschema.TablePgTables),
+			strings.ToLower(infoschema.TablePgCollations),
+			strings.ToLower(infoschema.TablePgViews),
+			strings.ToLower(infoschema.TablePgSequences),
+			strings.ToLower(infoschema.TablePgTableConstraints),
+			strings.ToLower(infoschema.TablePgCharacterSets),
+			strings.ToLower(infoschema.TablePgCollationCharacterSetApplicability):
+			return &MemTableReaderExec{
+				baseExecutor: newBaseExecutor(b.ctx, v.Schema(), v.ID()),
+				table: v.Table,
+				retriever: &pgMemTableRetriever{
+					table: v.Table,
+					columns: v.Columns,
 				},
 			}
 		}

--- a/executor/ddl_test.go
+++ b/executor/ddl_test.go
@@ -21,11 +21,11 @@ import (
 	"strings"
 	"time"
 
-	. "github.com/pingcap/check"
-	"github.com/pingcap/failpoint"
 	"github.com/DigitalChinaOpenSource/DCParser/model"
 	"github.com/DigitalChinaOpenSource/DCParser/mysql"
 	"github.com/DigitalChinaOpenSource/DCParser/terror"
+	. "github.com/pingcap/check"
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/ddl"
 	ddltestutil "github.com/pingcap/tidb/ddl/testutil"
 	ddlutil "github.com/pingcap/tidb/ddl/util"
@@ -429,7 +429,7 @@ func (s *testSuite6) TestCreateDropView(c *C) {
 	tk.MustExec("create view v as select * from t_v1;")
 	tk.MustExec("create or replace view v  as select * from t_v2;")
 	tk.MustQuery("select * from information_schema.views where table_name ='v';").Check(
-		testkit.Rows("def test v SELECT `test`.`t_v2`.`a`,`test`.`t_v2`.`b` FROM `test`.`t_v2` CASCADED NO @ DEFINER utf8mb4 utf8mb4_bin"))
+		testkit.Rows("postgres test v SELECT `test`.`t_v2`.`a`,`test`.`t_v2`.`b` FROM `test`.`t_v2` CASCADED NO <nil> <nil> <nil> <nil> @ DEFINER utf8mb4 utf8mb4_bin"))
 }
 
 func (s *testSuite6) TestCreateDropIndex(c *C) {

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -41,16 +41,16 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/protobuf/proto"
-	. "github.com/pingcap/check"
-	"github.com/pingcap/errors"
-	"github.com/pingcap/failpoint"
-	pb "github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/DigitalChinaOpenSource/DCParser"
 	"github.com/DigitalChinaOpenSource/DCParser/auth"
 	"github.com/DigitalChinaOpenSource/DCParser/model"
 	"github.com/DigitalChinaOpenSource/DCParser/mysql"
 	"github.com/DigitalChinaOpenSource/DCParser/terror"
+	"github.com/golang/protobuf/proto"
+	. "github.com/pingcap/check"
+	"github.com/pingcap/errors"
+	"github.com/pingcap/failpoint"
+	pb "github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/ddl"
 	"github.com/pingcap/tidb/domain"
@@ -2156,8 +2156,8 @@ func (s *testSuiteP2) TestTableScan(c *C) {
 	c.Assert(len(result.Rows()), GreaterEqual, 4)
 	tk.MustExec("use test")
 	tk.MustExec("create database mytest")
-	rowStr1 := fmt.Sprintf("%s %s %s %s %v", "def", "mysql", "utf8mb4", "utf8mb4_bin", nil)
-	rowStr2 := fmt.Sprintf("%s %s %s %s %v", "def", "mytest", "utf8mb4", "utf8mb4_bin", nil)
+	rowStr1 := fmt.Sprintf("%s %s %s %v %v %s %v %s", "postgres", "mysql", "root", nil, nil, "utf8mb4", nil, "utf8mb4_bin")
+	rowStr2 := fmt.Sprintf("%s %s %s %v %v %s %v %s", "postgres", "mytest", "root", nil, nil, "utf8mb4", nil, "utf8mb4_bin")
 	tk.MustExec("use information_schema")
 	result = tk.MustQuery("select * from schemata where schema_name = 'mysql'")
 	result.Check(testkit.Rows(rowStr1))

--- a/executor/infoschema_reader.go
+++ b/executor/infoschema_reader.go
@@ -37,12 +37,12 @@ import (
 	"sync"
 	"time"
 
-	"github.com/cznic/mathutil"
-	"github.com/pingcap/errors"
 	"github.com/DigitalChinaOpenSource/DCParser/charset"
 	"github.com/DigitalChinaOpenSource/DCParser/model"
 	"github.com/DigitalChinaOpenSource/DCParser/mysql"
 	"github.com/DigitalChinaOpenSource/DCParser/terror"
+	"github.com/cznic/mathutil"
+	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/domain"
 	"github.com/pingcap/tidb/domain/infosync"
 	"github.com/pingcap/tidb/infoschema"
@@ -504,7 +504,6 @@ func (e *memtableRetriever) setDataFromTables(ctx sessionctx.Context, schemas []
 					table.Comment,         // TABLE_COMMENT
 					table.ID,              // TIDB_TABLE_ID
 					shardingInfo,          // TIDB_ROW_ID_SHARDING_INFO
-					nil,				   //
 				)
 				rows = append(rows, record)
 			} else {
@@ -1878,6 +1877,8 @@ func (e *hugeMemTableRetriever) retrieve(ctx context.Context, sctx sessionctx.Co
 	switch e.table.Name.O {
 	case infoschema.TableColumns:
 		err = e.setDataForColumns(sctx)
+	case infoschema.TablePgColumns:
+		err = e.setDataForPgColumns(sctx)
 	}
 	if err != nil {
 		return nil, err
@@ -1919,12 +1920,12 @@ func (e *pgMemTableRetriever) retrieve(ctx context.Context, sctx sessionctx.Cont
 	if e.retrieved {
 		return nil, nil
 	}
-
 	//Cache the ret full rows in schemataRetriever
 	if !e.initialized {
 		is := infoschema.GetInfoSchema(sctx)
 		dbs := is.AllSchemas()
 		sort.Sort(infoschema.SchemasSorter(dbs))
+		var err error
 		switch e.table.Name.O {
 		case infoschema.TablePgInformationsSchemaCatalogName:
 			e.setDataForPgInformationSchemaCatalogName()
@@ -1934,7 +1935,24 @@ func (e *pgMemTableRetriever) retrieve(ctx context.Context, sctx sessionctx.Cont
 			e.setDataForPgAdministrableRoleAuthorizations()
 		case infoschema.TablePgEnabledRoles:
 			e.setDataForPgEnabledRoles()
+		case infoschema.TablePgTables:
+			err = e.setDataForPgTables(sctx, dbs)
+		case infoschema.TablePgCollations:
+			e.setDataForPgCollations()
+		case infoschema.TablePgSequences:
+			e.setDataForPgSequences(sctx, dbs)
+		case infoschema.TablePgViews:
+			e.setDataForPgViews(sctx,dbs)
+		case infoschema.TablePgTableConstraints:
+			e.setDataForPgTableConstraints(sctx,dbs)
+		case infoschema.TablePgCharacterSets:
+			e.setDataForPgCharacterSets()
+		case infoschema.TablePgCollationCharacterSetApplicability:
+			e.SetDataForCollationCharacterSetApplicability()
 			// todo set data for tables
+		}
+		if err != nil {
+			return nil, err
 		}
 		e.initialized = true
 	}
@@ -1953,6 +1971,7 @@ func (e *pgMemTableRetriever) retrieve(ctx context.Context, sctx sessionctx.Cont
 	e.rowIdx += retCount
 	return adjustColumns(ret, e.columns, e.table), nil
 }
+
 // setDataForPgInformationSchemaCatalogName set data for pgTable information_schema_catalog_name
 // todo 这个值应该是动态的，这里先写死
 func (e *pgMemTableRetriever) setDataForPgInformationSchemaCatalogName(){
@@ -1986,6 +2005,17 @@ func (e *pgMemTableRetriever) setDataForPgSchemata(ctx sessionctx.Context, schem
 
 	for _, schema := range schemas {
 
+		charset := mysql.DefaultCharset
+		collation := mysql.DefaultCollationName
+
+		if len(schema.Charset) > 0 {
+			charset = schema.Charset //overwrite default
+		}
+
+		if len(schema.Collate) > 0 {
+			collation = schema.Collate //overwrite default
+		}
+
 		if checker != nil && !checker.RequestVerification(ctx.GetSessionVars().ActiveRoles, schema.Name.L, "", "", mysql.AllPrivMask) {
 			continue
 		}
@@ -1996,12 +2026,155 @@ func (e *pgMemTableRetriever) setDataForPgSchemata(ctx sessionctx.Context, schem
 			"root",               	// schema_owner
 			nil,             		// default_character_set_catalog
 			nil,					// default_character_set_schema
-			nil,					// default_character_set_name
+			charset,				// default_character_set_name
 			nil, 					// sql_path
+			collation,				// DEFAULT_COLLATION_NAME
 		)
 		rows = append(rows, record)
 	}
 	e.rows = rows
+}
+
+// setDataForPgTables set data for pgTable tables
+func (e *pgMemTableRetriever) setDataForPgTables(ctx sessionctx.Context, schemas []*model.DBInfo) error {
+	tableRowsMap, colLengthMap, err :=tableStatsCache.get(ctx)
+	if err != nil {
+		return err
+	}
+
+	checker := privilege.GetPrivilegeManager(ctx)
+
+	var rows [][]types.Datum
+	createTimeTp := mysql.TypeDatetime
+	for _ , schema := range schemas{
+		for _, table := range schema.Tables{
+			collation := table.Collate
+			if collation == ""{
+				collation = mysql.DefaultCollationName
+			}
+			createTime := types.NewTime(types.FromGoTime(table.GetUpdateTime()),createTimeTp,types.DefaultFsp)
+
+			createOptions := ""
+
+			if table.IsSequence() {
+				continue
+			}
+
+			if checker != nil && !checker.RequestVerification(ctx.GetSessionVars().ActiveRoles, schema.Name.L, table.Name.L, "", mysql.AllPrivMask){
+				continue
+			}
+
+			if !table.IsView(){
+				if table.GetPartitionInfo()!=nil{
+					createOptions = "partitioned"
+				}
+				var autoIncID interface{}
+				hasAutoincID, _ :=infoschema.HasAutoIncrementColumn(table)
+				if hasAutoincID {
+					autoIncID, err = getAutoIncrementID(ctx,schema,table)
+					if err != nil{
+						return err
+					}
+				}
+				var rowCount, dataLength, indexLength uint64
+				if table.GetPartitionInfo() == nil {
+					rowCount = tableRowsMap[table.ID]
+					dataLength,indexLength = getDataAndIndexLength(table, table.ID, rowCount, colLengthMap)
+				}else {
+					for _ , pi := range table.GetPartitionInfo().Definitions{
+						rowCount += tableRowsMap[pi.ID]
+						parDataLen, parIndexLen := getDataAndIndexLength(table, pi.ID, tableRowsMap[pi.ID], colLengthMap)
+						dataLength += parDataLen
+						indexLength += parIndexLen
+					}
+				}
+				avgRowLength := uint64(0)
+				if rowCount != 0 {
+					avgRowLength = dataLength / rowCount
+				}
+				var tableType string
+				switch schema.Name.L {
+				case util.InformationSchemaName.L, util.PerformanceSchemaName.L,
+					util.MetricSchemaName.L:
+						tableType = "SYSTEM VIEW"
+				default:
+					tableType = "BASE TABLE"
+				}
+				shardingInfo := infoschema.GetShardingInfo(schema, table)
+				record := types.MakeDatums(
+					"postgres", // TABLE_CATALOG
+					schema.Name.O,         // TABLE_SCHEMA
+					table.Name.O,          // TABLE_NAME
+					tableType,             // TABLE_TYPE
+					nil,				   // self_referencing_column_name
+					nil,				   // reference_generation
+					nil,				   // user_defined_type_catalog
+					nil,				   // user_defined_type_schema
+					nil,				   // user_defined_type_name
+					nil,                   // is_insertable_into
+					nil,                   // is_typed
+					nil,                   // commit_action
+					"InnoDB",              // ENGINE
+					uint64(10),            // VERSION
+					"Compact",             // ROW_FORMAT
+					rowCount,              // TABLE_ROWS
+					avgRowLength,          // AVG_ROW_LENGTH
+					dataLength,            // DATA_LENGTH
+					uint64(0),             // MAX_DATA_LENGTH
+					indexLength,           // INDEX_LENGTH
+					uint64(0),             // DATA_FREE
+					autoIncID,             // AUTO_INCREMENT
+					createTime,            // CREATE_TIME
+					nil,                   // UPDATE_TIME
+					nil,                   // CHECK_TIME
+					collation,             // TABLE_COLLATION
+					nil,                   // CHECKSUM
+					createOptions,         // CREATE_OPTIONS
+					table.Comment,         // TABLE_COMMENT
+					table.ID,              // TIDB_TABLE_ID
+					shardingInfo,          // TIDB_ROW_ID_SHARDING_INFO
+				)
+				rows = append(rows, record)
+			} else {
+				record := types.MakeDatums(
+					"postgres", // TABLE_CATALOG
+					schema.Name.O,         // TABLE_SCHEMA
+					table.Name.O,          // TABLE_NAME
+					"VIEW",                // TABLE_TYPE
+					nil,				   // self_referencing_column_name
+					nil,				   // reference_generation
+					nil,				   // user_defined_type_catalog
+					nil,				   // user_defined_type_schema
+					nil,				   // user_defined_type_name
+					nil,                   // is_insertable_into
+					nil,                   // is_typed
+					nil,                   // commit_action
+					nil,                   // ENGINE
+					nil,                   // VERSION
+					nil,                   // ROW_FORMAT
+					nil,                   // TABLE_ROWS
+					nil,                   // AVG_ROW_LENGTH
+					nil,                   // DATA_LENGTH
+					nil,                   // MAX_DATA_LENGTH
+					nil,                   // INDEX_LENGTH
+					nil,                   // DATA_FREE
+					nil,                   // AUTO_INCREMENT
+					createTime,            // CREATE_TIME
+					nil,                   // UPDATE_TIME
+					nil,                   // CHECK_TIME
+					nil,                   // TABLE_COLLATION
+					nil,                   // CHECKSUM
+					nil,                   // CREATE_OPTIONS
+					"VIEW",                // TABLE_COMMENT
+					table.ID,              // TIDB_TABLE_ID
+					nil,                   // TIDB_ROW_ID_SHARDING_INFO
+				)
+				rows = append(rows, record)
+			}
+		}
+	}
+	e.rows = rows
+	return nil
 }
 
 // setDataForPgEnabledRoles set data for pgTable enabled_roles
@@ -2017,5 +2190,372 @@ func (e *pgMemTableRetriever) setDataForPgEnabledRoles() {
 			"admin",  // catalog_name
 		),
 	)
+	e.rows = rows
+}
+
+// setDataForPgCollations set data for pgTable collations
+func (e *pgMemTableRetriever) setDataForPgCollations() {
+	var rows [][]types.Datum
+	collations := collate.GetSupportedCollations()
+	for _, collation := range collations {
+		isDefault := ""
+		if collation.IsDefault {
+			isDefault = "Yes"
+		}
+		rows = append(rows,
+			types.MakeDatums("postgres","pg_catalog",collation.Name,"NO PAD", collation.CharsetName, collation.ID, isDefault, "Yes", 1),
+		)
+	}
+	e.rows = rows
+}
+
+// setDataForPgColumns set data for pgTable Columns
+func (e *hugeMemTableRetriever) setDataForPgColumns(ctx sessionctx.Context) error {
+	checker := privilege.GetPrivilegeManager(ctx)
+	e.rows = e.rows[:0]
+	batch := 1024
+	for ; e.dbsIdx < len(e.dbs); e.dbsIdx++ {
+		schema := e.dbs[e.dbsIdx]
+		for e.tblIdx < len(schema.Tables) {
+			table := schema.Tables[e.tblIdx]
+			e.tblIdx++
+			if checker != nil && !checker.RequestVerification(ctx.GetSessionVars().ActiveRoles, schema.Name.L, table.Name.L, "", mysql.AllPrivMask) {
+				continue
+			}
+
+			e.dataForPgColumnsInTable(schema, table)
+			if len(e.rows) >= batch {
+				return nil
+			}
+		}
+		e.tblIdx = 0
+	}
+	return nil
+}
+
+func (e *hugeMemTableRetriever) dataForPgColumnsInTable(schema *model.DBInfo, tbl *model.TableInfo) {
+	for i, col := range tbl.Columns {
+		if col.Hidden {
+			continue
+		}
+		var charMaxLen, charOctLen, numericPrecision, numericScale, datetimePrecision interface{}
+		colLen, decimal := col.Flen, col.Decimal
+		defaultFlen, defaultDecimal := mysql.GetDefaultFieldLengthAndDecimal(col.Tp)
+		if decimal == types.UnspecifiedLength {
+			decimal = defaultDecimal
+		}
+		if colLen == types.UnspecifiedLength {
+			colLen = defaultFlen
+		}
+		if col.Tp == mysql.TypeSet {
+			// Example: In MySQL set('a','bc','def','ghij') has length 13, because
+			// len('a')+len('bc')+len('def')+len('ghij')+len(ThreeComma)=13
+			// Reference link: https://bugs.mysql.com/bug.php?id=22613
+			colLen = 0
+			for _, ele := range col.Elems {
+				colLen += len(ele)
+			}
+			if len(col.Elems) != 0 {
+				colLen += (len(col.Elems) - 1)
+			}
+			charMaxLen = colLen
+			charOctLen = colLen
+		} else if col.Tp == mysql.TypeEnum {
+			// Example: In MySQL enum('a', 'ab', 'cdef') has length 4, because
+			// the longest string in the enum is 'cdef'
+			// Reference link: https://bugs.mysql.com/bug.php?id=22613
+			colLen = 0
+			for _, ele := range col.Elems {
+				if len(ele) > colLen {
+					colLen = len(ele)
+				}
+			}
+			charMaxLen = colLen
+			charOctLen = colLen
+		} else if types.IsString(col.Tp) {
+			charMaxLen = colLen
+			charOctLen = colLen
+		} else if types.IsTypeFractionable(col.Tp) {
+			datetimePrecision = decimal
+		} else if types.IsTypeNumeric(col.Tp) {
+			numericPrecision = colLen
+			if col.Tp != mysql.TypeFloat && col.Tp != mysql.TypeDouble {
+				numericScale = decimal
+			} else if decimal != -1 {
+				numericScale = decimal
+			}
+		}
+		columnType := col.FieldType.InfoSchemaStr()
+		columnDesc := table.NewColDesc(table.ToColumn(col))
+		var columnDefault interface{}
+		if columnDesc.DefaultValue != nil {
+			columnDefault = fmt.Sprintf("%v", columnDesc.DefaultValue)
+		}
+		var record = types.MakeDatums()
+		if schema.Name.O == "information_schema" {
+			record = types.MakeDatums(
+				"postgres",                // TABLE_CATALOG
+				schema.Name.O,                        // TABLE_SCHEMA
+				tbl.Name.O,                           // TABLE_NAME
+				col.Name.O,                           // COLUMN_NAME
+				i+1,                                  // ORIGINAL_POSITION
+				columnDefault,                        // COLUMN_DEFAULT
+				columnDesc.Null,                      // IS_NULLABLE
+				types.TypeToStr(col.Tp, col.Charset), // DATA_TYPE
+				charMaxLen,                           // CHARACTER_MAXIMUM_LENGTH
+				charOctLen,                           // CHARACTER_OCTET_LENGTH
+				numericPrecision,                     // NUMERIC_PRECISION
+				nil,                                  // numeric_precision_radix
+				numericScale,                         // NUMERIC_SCALE
+				datetimePrecision,                    // DATETIME_PRECISION
+				nil,								  // interval_type
+				nil,								  // interval_precision
+				nil, 								  // character_set_catalog
+				nil,								  // character_set_schema
+				columnDesc.Charset,                   // CHARACTER_SET_NAME
+				"postgres",							  // collation_catalog
+				"pg_catalog",						  // collation_schema
+				columnDesc.Collation,                 // COLLATION_NAME
+				"postgres",							  // domain_catalog
+				"information_schema",				  // domain_schema
+				"sql_identifier",					  // domain_name
+				"postgres",							  // udt_catalog
+				"pg_catalog",                         // udt_schema
+				nil,								  // udt_name
+				nil,								  // scope_catalog
+				nil,								  // scope_schema
+				nil,								  // scope_name
+				nil,								  // maximum_cardinality
+				nil,								  // dtd_identifier
+				nil,								  // is_self_referencing
+				nil,								  // is_identity
+				nil,								  // identity_generation
+				nil,								  // identity_start
+				nil,								  // identity_increment
+				nil,								  // identity_maximum
+				nil,								  // identity_minimum
+				nil,						 		  // identity_cycle
+				nil,								  // is_generated
+				col.GeneratedExprString,              // GENERATION_EXPRESSION
+				nil,								  // is_updatable
+				columnType,                           // COLUMN_TYPE
+				columnDesc.Key,                       // COLUMN_KEY
+				columnDesc.Extra,                     // EXTRA
+				"select,insert,update,references",    // PRIVILEGES
+				columnDesc.Comment,                   // COLUMN_COMMENT
+			)
+		}else{
+			record = types.MakeDatums(
+				"postgres",                // TABLE_CATALOG
+				schema.Name.O,                        // TABLE_SCHEMA
+				tbl.Name.O,                           // TABLE_NAME
+				col.Name.O,                           // COLUMN_NAME
+				i+1,                                  // ORIGINAL_POSITION
+				columnDefault,                        // COLUMN_DEFAULT
+				columnDesc.Null,                      // IS_NULLABLE
+				types.TypeToStr(col.Tp, col.Charset), // DATA_TYPE
+				charMaxLen,                           // CHARACTER_MAXIMUM_LENGTH
+				charOctLen,                           // CHARACTER_OCTET_LENGTH
+				numericPrecision,                     // NUMERIC_PRECISION
+				nil,                                  // numeric_precision_radix
+				numericScale,                         // NUMERIC_SCALE
+				datetimePrecision,                    // DATETIME_PRECISION
+				nil,								  // interval_type
+				nil,								  // interval_precision
+				nil, 								  // character_set_catalog
+				nil,								  // character_set_schema
+				columnDesc.Charset,                   // CHARACTER_SET_NAME
+				nil,							  	  // collation_catalog
+				nil,						 		  // collation_schema
+				columnDesc.Collation,                 // COLLATION_NAME
+				nil,							  	  // domain_catalog
+				nil,				  				  // domain_schema
+				nil,					  			  // domain_name
+				"postgres",							  // udt_catalog
+				"pg_catalog",                         // udt_schema
+				nil,								  // udt_name
+				nil,								  // scope_catalog
+				nil,								  // scope_schema
+				nil,								  // scope_name
+				nil,								  // maximum_cardinality
+				nil,								  // dtd_identifier
+				nil,								  // is_self_referencing
+				nil,								  // is_identity
+				nil,								  // identity_generation
+				nil,								  // identity_start
+				nil,								  // identity_increment
+				nil,								  // identity_maximum
+				nil,								  // identity_minimum
+				nil,						 		  // identity_cycle
+				nil,								  // is_generated
+				col.GeneratedExprString,              // GENERATION_EXPRESSION
+				nil,								  // is_updatable
+				columnType,                           // COLUMN_TYPE
+				columnDesc.Key,                       // COLUMN_KEY
+				columnDesc.Extra,                     // EXTRA
+				"select,insert,update,references",    // PRIVILEGES
+				columnDesc.Comment,                   // COLUMN_COMMENT
+			)
+		}
+		e.rows = append(e.rows, record)
+	}
+}
+
+// setDataForPgSequences set data for pgTable sequences
+func (e *pgMemTableRetriever) setDataForPgSequences(ctx sessionctx.Context, schemas []*model.DBInfo) {
+	checker := privilege.GetPrivilegeManager(ctx)
+	var rows [][]types.Datum
+	for _, schema := range schemas {
+		for _, table := range schema.Tables {
+			if !table.IsSequence() {
+				continue
+			}
+			if checker != nil && !checker.RequestVerification(ctx.GetSessionVars().ActiveRoles, schema.Name.L, table.Name.L, "", mysql.AllPrivMask) {
+				continue
+			}
+			record := types.MakeDatums(
+				"postgres",     	   // sequence_catalog
+				schema.Name.O,             // sequence_schema
+				table.Name.O,              // sequence_name
+				nil,                       // data_type
+				nil,                       // numeric_precision
+				nil,                       // numeric_precision_radix
+				nil,                       // numeric_scale
+				nil,                       // start_value
+				nil,                       // minimum_value
+				nil,					   // maximum_value
+				table.Sequence.Increment,  // INCREMENT
+				nil,					   // cycle_option
+				"postgres",				   // TABLE_CATALOG
+				table.Sequence.Cache,      // Cache
+				table.Sequence.CacheValue, // CACHE_VALUE
+				table.Sequence.Cycle,      // CYCLE
+				table.Sequence.MaxValue,   // MAX_VALUE
+				table.Sequence.MinValue,   // MIN_VALUE
+				table.Sequence.Start,      // START
+				table.Sequence.Comment,    // COMMENT
+			)
+			rows = append(rows, record)
+		}
+	}
+	e.rows = rows
+}
+
+func (e *pgMemTableRetriever) setDataForPgViews(ctx sessionctx.Context, schemas []*model.DBInfo) {
+	checker := privilege.GetPrivilegeManager(ctx)
+	var rows [][]types.Datum
+	for _, schema := range schemas {
+		for _, table := range schema.Tables {
+			if !table.IsView() {
+				continue
+			}
+			collation := table.Collate
+			charset := table.Charset
+			if collation == "" {
+				collation = mysql.DefaultCollationName
+			}
+			if charset == "" {
+				charset = mysql.DefaultCharset
+			}
+			if checker != nil && !checker.RequestVerification(ctx.GetSessionVars().ActiveRoles, schema.Name.L, table.Name.L, "", mysql.AllPrivMask) {
+				continue
+			}
+			record := types.MakeDatums(
+				"postgres",           	 // TABLE_CATALOG
+				schema.Name.O,                   // TABLE_SCHEMA
+				table.Name.O,                    // TABLE_NAME
+				table.View.SelectStmt,           // VIEW_DEFINITION
+				table.View.CheckOption.String(), // CHECK_OPTION
+				"NO",                            // IS_UPDATABLE
+				nil,							 // is_insertable_into
+				nil,							 // is_trigger_updatable
+				nil,							 // is_trigger_deletable
+				nil,							 // is_trigger_insertable_into
+				table.View.Definer.String(),     // DEFINER
+				table.View.Security.String(),    // SECURITY_TYPE
+				charset,                         // CHARACTER_SET_CLIENT
+				collation,                       // COLLATION_CONNECTION
+			)
+			rows = append(rows, record)
+		}
+	}
+	e.rows = rows
+}
+
+func (e *pgMemTableRetriever) setDataForPgTableConstraints(ctx sessionctx.Context, schemas []*model.DBInfo) {
+	checker := privilege.GetPrivilegeManager(ctx)
+	var rows [][]types.Datum
+	for _, schema := range schemas {
+		for _, tbl := range schema.Tables {
+			if checker != nil && !checker.RequestVerification(ctx.GetSessionVars().ActiveRoles, schema.Name.L, tbl.Name.L, "", mysql.AllPrivMask) {
+				continue
+			}
+
+			if tbl.PKIsHandle {
+				record := types.MakeDatums(
+					"postgres",          // CONSTRAINT_CATALOG
+					schema.Name.O,             // CONSTRAINT_SCHEMA
+					mysql.PrimaryKeyName,      // CONSTRAINT_NAME
+					"postgres",				   // table_catalog
+					schema.Name.O,             // TABLE_SCHEMA
+					tbl.Name.O,                // TABLE_NAME
+					infoschema.PrimaryKeyType, // CONSTRAINT_TYPE
+					nil,                       // is_deferrable
+					nil,                       // initially_deferred
+					nil,                       // enforced
+				)
+				rows = append(rows, record)
+			}
+
+			for _, idx := range tbl.Indices {
+				var cname, ctype string
+				if idx.Primary {
+					cname = mysql.PrimaryKeyName
+					ctype = infoschema.PrimaryKeyType
+				} else if idx.Unique {
+					cname = idx.Name.O
+					ctype = infoschema.UniqueKeyType
+				} else {
+					// The index has no constriant.
+					continue
+				}
+				record := types.MakeDatums(
+					"postgres", // CONSTRAINT_CATALOG
+					schema.Name.O,         // CONSTRAINT_SCHEMA
+					cname,                 // CONSTRAINT_NAME
+					"postgres",            // table_catalog
+					schema.Name.O,         // TABLE_SCHEMA
+					tbl.Name.O,            // TABLE_NAME
+					ctype,                 // CONSTRAINT_TYPE
+					nil,                   // is_deferrable
+					nil,                   // initially_deferred
+					nil,                   // enforced
+				)
+				rows = append(rows, record)
+			}
+		}
+	}
+	e.rows = rows
+}
+
+func (e *pgMemTableRetriever) setDataForPgCharacterSets() {
+	var rows [][]types.Datum
+	charsets := charset.GetSupportedCharsets()
+	for _, charset := range charsets {
+		rows = append(rows,
+			types.MakeDatums(nil, nil, charset.Name, "UCS", charset.Name, "postgres", nil, charset.DefaultCollation, charset.Desc, charset.Maxlen),
+		)
+	}
+	e.rows = rows
+}
+
+func (e *pgMemTableRetriever) SetDataForCollationCharacterSetApplicability() {
+	var rows [][]types.Datum
+	collations := collate.GetSupportedCollations()
+	for _, collation := range collations {
+		rows = append(rows,
+			types.MakeDatums("postgres","pg_catalog",collation.Name, nil, nil, collation.CharsetName),
+		)
+	}
 	e.rows = rows
 }

--- a/executor/seqtest/seq_executor_test.go
+++ b/executor/seqtest/seq_executor_test.go
@@ -43,14 +43,14 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/pingcap/check"
-	"github.com/pingcap/errors"
-	"github.com/pingcap/failpoint"
-	pb "github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/DigitalChinaOpenSource/DCParser"
 	"github.com/DigitalChinaOpenSource/DCParser/model"
 	"github.com/DigitalChinaOpenSource/DCParser/mysql"
 	"github.com/DigitalChinaOpenSource/DCParser/terror"
+	. "github.com/pingcap/check"
+	"github.com/pingcap/errors"
+	"github.com/pingcap/failpoint"
+	pb "github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/ddl"
 	ddltestutil "github.com/pingcap/tidb/ddl/testutil"
@@ -1245,6 +1245,17 @@ func (s *seqTestSuite) TestShowForNewCollations(c *C) {
 
 	tk := testkit.NewTestKit(c, s.store)
 	expectRows := testkit.Rows(
+		"postgres pg_catalog ascii_bin NO PAD ascii 65 Yes Yes 1",
+		"postgres pg_catalog binary NO PAD binary 63 Yes Yes 1",
+		"postgres pg_catalog latin1_bin NO PAD latin1 47 Yes Yes 1",
+		"postgres pg_catalog utf8_bin NO PAD utf8 83 Yes Yes 1",
+		"postgres pg_catalog utf8_general_ci NO PAD utf8 33  Yes 1",
+		"postgres pg_catalog utf8_unicode_ci NO PAD utf8 192  Yes 1",
+		"postgres pg_catalog utf8mb4_bin NO PAD utf8mb4 46 Yes Yes 1",
+		"postgres pg_catalog utf8mb4_general_ci NO PAD utf8mb4 45  Yes 1",
+		"postgres pg_catalog utf8mb4_unicode_ci NO PAD utf8mb4 224  Yes 1",
+	)
+	expectRowsTiDB := testkit.Rows(
 		"ascii_bin ascii 65 Yes Yes 1",
 		"binary binary 63 Yes Yes 1",
 		"latin1_bin latin1 47 Yes Yes 1",
@@ -1255,7 +1266,7 @@ func (s *seqTestSuite) TestShowForNewCollations(c *C) {
 		"utf8mb4_general_ci utf8mb4 45  Yes 1",
 		"utf8mb4_unicode_ci utf8mb4 224  Yes 1",
 	)
-	tk.MustQuery("show collation").Check(expectRows)
+	tk.MustQuery("show collation").Check(expectRowsTiDB)
 	tk.MustQuery("select * from information_schema.COLLATIONS").Check(expectRows)
 }
 

--- a/executor/show_stats_test.go
+++ b/executor/show_stats_test.go
@@ -251,7 +251,6 @@ func (s *testShowStatsSuite) TestShowStatusSnapshot(c *C) {
 	tk.MustExec(updateSafePoint)
 
 	snapshotTime := time.Now()
-
 	tk.MustExec("drop table t;")
 	tk.MustQuery("show table status;").Check(testkit.Rows())
 	tk.MustExec("set @@tidb_snapshot = '" + snapshotTime.Format("2006-01-02 15:04:05.999999") + "'")

--- a/executor/show_test.go
+++ b/executor/show_test.go
@@ -18,12 +18,12 @@ import (
 	"fmt"
 	"strings"
 
-	. "github.com/pingcap/check"
-	"github.com/pingcap/errors"
-	"github.com/pingcap/failpoint"
 	"github.com/DigitalChinaOpenSource/DCParser/auth"
 	"github.com/DigitalChinaOpenSource/DCParser/model"
 	"github.com/DigitalChinaOpenSource/DCParser/mysql"
+	. "github.com/pingcap/check"
+	"github.com/pingcap/errors"
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/domain"
 	"github.com/pingcap/tidb/executor"
 	plannercore "github.com/pingcap/tidb/planner/core"
@@ -957,9 +957,9 @@ func (s *testSuite5) TestShowBuiltin(c *C) {
 	res := tk.MustQuery("show builtins;")
 	c.Assert(res, NotNil)
 	rows := res.Rows()
-	c.Assert(267, Equals, len(rows))
+	c.Assert(278, Equals, len(rows))
 	c.Assert("abs", Equals, rows[0][0].(string))
-	c.Assert("yearweek", Equals, rows[266][0].(string))
+	c.Assert("yearweek", Equals, rows[277][0].(string))
 }
 
 func (s *testSuite5) TestShowClusterConfig(c *C) {

--- a/infoschema/tables_test.go
+++ b/infoschema/tables_test.go
@@ -24,14 +24,14 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gorilla/mux"
-	. "github.com/pingcap/check"
-	"github.com/pingcap/failpoint"
-	"github.com/pingcap/fn"
 	"github.com/DigitalChinaOpenSource/DCParser/auth"
 	"github.com/DigitalChinaOpenSource/DCParser/model"
 	"github.com/DigitalChinaOpenSource/DCParser/mysql"
 	"github.com/DigitalChinaOpenSource/DCParser/terror"
+	"github.com/gorilla/mux"
+	. "github.com/pingcap/check"
+	"github.com/pingcap/failpoint"
+	"github.com/pingcap/fn"
 	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/domain"
 	"github.com/pingcap/tidb/infoschema"
@@ -981,9 +981,9 @@ func (s *testTableSuite) TestStmtSummaryTable(c *C) {
 		from information_schema.statements_summary
 		where digest_text like 'select * from t%'`,
 	).Check(testkit.Rows("Select test test.t t:k 1 2 0 0 0 0 0 0 0 0 0 select * from t where a=2 \tid                \ttask     \testRows\toperator info\n" +
-		"\tIndexLookUp_10    \troot     \t100    \t\n" +
-		"\t├─IndexRangeScan_8\tcop[tikv]\t100    \ttable:t, index:k(a), range:[2,2], keep order:false, stats:pseudo\n" +
-		"\t└─TableRowIDScan_9\tcop[tikv]\t100    \ttable:t, keep order:false, stats:pseudo"))
+		 "\tIndexLookUp_10    \troot     \t10     \t\n" +
+	     "\t├─IndexRangeScan_8\tcop[tikv]\t10     \ttable:t, index:k(a), range:[2,2], keep order:false, stats:pseudo\n" +
+	     "\t└─TableRowIDScan_9\tcop[tikv]\t10     \ttable:t, keep order:false, stats:pseudo"))
 
 	// select ... order by
 	tk.MustQuery(`select stmt_type, schema_name, table_names, index_names, exec_count, sum_cop_task_num, avg_total_keys,
@@ -1003,9 +1003,9 @@ func (s *testTableSuite) TestStmtSummaryTable(c *C) {
 		where digest_text like 'select * from t%'`,
 	).Check(testkit.Rows(
 		"Select test test.t t:k 2 4 0 0 0 0 0 0 0 0 0 select * from t where a=2 \tid                \ttask     \testRows\toperator info\n" +
-			"\tIndexLookUp_10    \troot     \t100    \t\n" +
-			"\t├─IndexRangeScan_8\tcop[tikv]\t100    \ttable:t, index:k(a), range:[2,2], keep order:false, stats:pseudo\n" +
-			"\t└─TableRowIDScan_9\tcop[tikv]\t100    \ttable:t, keep order:false, stats:pseudo"))
+			"\tIndexLookUp_10    \troot     \t10     \t\n" +
+	     "\t├─IndexRangeScan_8\tcop[tikv]\t10     \ttable:t, index:k(a), range:[2,2], keep order:false, stats:pseudo\n" +
+	     "\t└─TableRowIDScan_9\tcop[tikv]\t10     \ttable:t, keep order:false, stats:pseudo"))
 
 	// Disable it again.
 	tk.MustExec("set global tidb_enable_stmt_summary = false")
@@ -1053,9 +1053,9 @@ func (s *testTableSuite) TestStmtSummaryTable(c *C) {
 		from information_schema.statements_summary
 		where digest_text like 'select * from t%'`,
 	).Check(testkit.Rows("Select test test.t t:k 1 2 0 0 0 0 0 0 0 0 0 select * from t where a=2 \tid                \ttask     \testRows\toperator info\n" +
-		"\tIndexLookUp_10    \troot     \t1000   \t\n" +
-		"\t├─IndexRangeScan_8\tcop[tikv]\t1000   \ttable:t, index:k(a), range:[2,2], keep order:false, stats:pseudo\n" +
-		"\t└─TableRowIDScan_9\tcop[tikv]\t1000   \ttable:t, keep order:false, stats:pseudo"))
+		     "\tIndexLookUp_10    \troot     \t10     \t\n" +
+	     "\t├─IndexRangeScan_8\tcop[tikv]\t10     \ttable:t, index:k(a), range:[2,2], keep order:false, stats:pseudo\n" +
+	     "\t└─TableRowIDScan_9\tcop[tikv]\t10     \ttable:t, keep order:false, stats:pseudo"))
 
 	// Disable it in global scope.
 	tk.MustExec("set global tidb_enable_stmt_summary = false")
@@ -1072,9 +1072,9 @@ func (s *testTableSuite) TestStmtSummaryTable(c *C) {
 		from information_schema.statements_summary
 		where digest_text like 'select * from t%'`,
 	).Check(testkit.Rows("Select test test.t t:k 2 4 0 0 0 0 0 0 0 0 0 select * from t where a=2 \tid                \ttask     \testRows\toperator info\n" +
-		"\tIndexLookUp_10    \troot     \t1000   \t\n" +
-		"\t├─IndexRangeScan_8\tcop[tikv]\t1000   \ttable:t, index:k(a), range:[2,2], keep order:false, stats:pseudo\n" +
-		"\t└─TableRowIDScan_9\tcop[tikv]\t1000   \ttable:t, keep order:false, stats:pseudo"))
+		     "\tIndexLookUp_10    \troot     \t10     \t\n" +
+	     "\t├─IndexRangeScan_8\tcop[tikv]\t10     \ttable:t, index:k(a), range:[2,2], keep order:false, stats:pseudo\n" +
+	     "\t└─TableRowIDScan_9\tcop[tikv]\t10     \ttable:t, keep order:false, stats:pseudo"))
 
 	// Unset session variable.
 	tk.MustExec("set session tidb_enable_stmt_summary = ''")

--- a/server/conn.go
+++ b/server/conn.go
@@ -71,14 +71,14 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/opentracing/opentracing-go"
-	"github.com/pingcap/errors"
-	"github.com/pingcap/failpoint"
 	"github.com/DigitalChinaOpenSource/DCParser"
 	"github.com/DigitalChinaOpenSource/DCParser/ast"
 	"github.com/DigitalChinaOpenSource/DCParser/auth"
 	"github.com/DigitalChinaOpenSource/DCParser/mysql"
 	"github.com/DigitalChinaOpenSource/DCParser/terror"
+	"github.com/opentracing/opentracing-go"
+	"github.com/pingcap/errors"
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/executor"
 	"github.com/pingcap/tidb/kv"
@@ -1027,9 +1027,9 @@ func (cc *clientConn) dispatch(ctx context.Context, data []byte) error {
 		return cc.handleStmtDescription(ctx, desc)
 	case 'H':            /* flush */
 	case 'S':            /* sync */
-		return cc.writeReadForQuery(ctx,cc.ctx.Status())
+		return cc.writeReadyForQuery(ctx, cc.ctx.Status())
 	case 'X':
-		return nil
+		return io.EOF
 	case 'd':            /* copy data */
 	case 'c':            /* copy done */
 	case 'f':            /* copy fail */
@@ -1066,13 +1066,13 @@ func (cc *clientConn) flush(ctx context.Context) error {
 	return cc.pkt.flush()
 }
 
-// writeOK 这个暂且先这么写,后面是否选择使用,待定
+// writeOK You can choose this method when you need to return complete and readyforquery directly to the client
 func (cc *clientConn) writeOK(ctx context.Context) error {
 	//msg := cc.ctx.LastMessage()
 	if err := cc.writeCommandComplete(); err != nil {
 		return err
 	}
-	return cc.writeReadForQuery(ctx,cc.ctx.Status())
+	return cc.writeReadyForQuery(ctx, cc.ctx.Status())
 }
 
 // writeOkWith 这个方法没什么用,后面可以考虑删除
@@ -1131,8 +1131,8 @@ func (cc *clientConn) writeError(ctx context.Context, e error) error {
 	// 发送错误后需要发送 ReadyForQuery 通知客户端可以继续执行命令
 	// 所以这里需要获取到事务状态是否处于空闲阶段
 	// todo 获取事务状态
-	cc.writeReadForQuery(ctx, cc.ctx.Status())
-	return cc.flush(ctx)
+
+	return cc.writeReadyForQuery(ctx, cc.ctx.Status())
 }
 
 // writeEOF writes an EOF packet.
@@ -1390,7 +1390,7 @@ func (cc *clientConn) handleQuery(ctx context.Context, sql string) (err error) {
 		return err
 	}
 	if len(stmts) == 0 {
-		return cc.writeCommandComplete()
+		return cc.writeOK(ctx)
 	}
 
 	var appendMultiStmtWarning bool
@@ -1483,7 +1483,7 @@ func (cc *clientConn) handleStmt(ctx context.Context, stmt ast.StmtNode, lastStm
 
 	// 如果是最后一个查询,则需要返回ReadyForQuery
 	if lastStmt{
-		if err:= cc.writeReadForQuery(ctx,status);err!=nil {
+		if err:= cc.writeReadyForQuery(ctx,status);err!=nil {
 			return err
 		}
 	}
@@ -1985,7 +1985,7 @@ func(cc *clientConn) handleSSLRequest(ctx context.Context) error{
 		return err
 	}
 
-	msg, ok := m.(*pgproto3.StartupMessage);
+	msg, ok := m.(*pgproto3.StartupMessage)
 
 	// 如果接收到的包不为启动包则报错
 	if !ok {
@@ -2059,7 +2059,7 @@ func(cc *clientConn) handleStartupMessage(ctx context.Context, startupMessage *p
 	}
 
 	// 发送 ReadyForQuery 表示一切准备就绪。"I"表示空闲(没有在事务中)
-	if err := cc.writeReadForQuery(ctx, mysql.ServerStatusAutocommit); err != nil{
+	if err := cc.writeReadyForQuery(ctx, mysql.ServerStatusAutocommit); err != nil {
 		logutil.Logger(ctx).Debug(err.Error())
 		return err
 	}
@@ -2110,7 +2110,7 @@ func (cc *clientConn) ReceiveStartupMessage() (pgproto3.FrontendMessage, error) 
 		}
 		return gssEncRequest, nil
 	default:
-		return nil, errors.New("unknown startup message code: " + string(code))
+		return nil, errors.New("unknown startup message code: " + fmt.Sprint(code))
 	}
 }
 
@@ -2269,7 +2269,7 @@ func (cc *clientConn) WriteRowDescription(columns []*ColumnInfo) error {
 }
 
 // writeCommandComplete 向客户端写回 CommandComplete 表示一次查询已经完成
-// 在 writeCommandComplete 之后需要向客户端写回 writeReadForQuery 发送服务端状态
+// 在 writeCommandComplete 之后需要向客户端写回 writeReadyForQuery 发送服务端状态
 // 这里只写向缓存，并不发送
 func (cc *clientConn) writeCommandComplete() error {
 	stmtType := strings.ToUpper(cc.ctx.GetSessionVars().StmtCtx.StmtType)
@@ -2322,19 +2322,20 @@ func (cc *clientConn) writeCloseComplete() error {
 	return cc.WriteData(closeComplete.Encode(nil))
 }
 
-// writeReadForQuery 向客户端写回 ReadyForQuery
+// writeReadyForQuery 向客户端写回 ReadyForQuery
 // status 为当前后端事务状态码。"I"表示空闲(没有在事务中)、"T"表示在事务中；"E"表示在失败的事务中(事务块结束前查询都回被驳回)
 // 调用该方法后会清空缓存，发送缓存中的所有报文
-func (cc *clientConn) writeReadForQuery(ctx context.Context, status uint16) error {
+func (cc *clientConn) writeReadyForQuery(ctx context.Context, status uint16) error {
 	pgStatus, err := convertMySQLServerStatusToPgSQLServerStatus(status)
 	if err != nil {
 		return err
 	}
 
-	readForReady := &pgproto3.ReadyForQuery{TxStatus: pgStatus}
-	if err := cc.WriteData(readForReady.Encode(nil)); err != nil{
+	readyForQuery := &pgproto3.ReadyForQuery{TxStatus: pgStatus}
+	if err := cc.WriteData(readyForQuery.Encode(nil)); err != nil {
 		return err
 	}
+
 	return cc.flush(ctx)
 }
 
@@ -2383,11 +2384,9 @@ func convertMySQLDataTypeToPgSQLDataType (mysqlType uint8) uint32 {
 	switch mysqlType {
 	case mysql.TypeUnspecified:
 		return pgtype.UnknownOID
-	case mysql.TypeTiny:
+	case mysql.TypeTiny, mysql.TypeShort:
 		return pgtype.Int2OID
-	case mysql.TypeShort:
-		return pgtype.Int2OID
-	case mysql.TypeLong:
+	case mysql.TypeLong, mysql.TypeInt24:
 		return pgtype.Int4OID
 	case mysql.TypeFloat:
 		return pgtype.Float4OID
@@ -2399,8 +2398,6 @@ func convertMySQLDataTypeToPgSQLDataType (mysqlType uint8) uint32 {
 		return pgtype.TimestampOID
 	case mysql.TypeLonglong:
 		return pgtype.Int8OID
-	case mysql.TypeInt24:  //未找到对应类型
-		return pgtype.UnknownOID
 	case mysql.TypeDate:
 		return pgtype.DateOID
 	case mysql.TypeDuration:
@@ -2418,22 +2415,14 @@ func convertMySQLDataTypeToPgSQLDataType (mysqlType uint8) uint32 {
 	case mysql.TypeJSON:
 		return pgtype.JSONOID
 	case mysql.TypeNewDecimal:
-		return pgtype.UnknownOID  //未找到对应类型
+		return pgtype.NumericOID
 	case mysql.TypeEnum:
-		return pgtype.UnknownOID  //未找到对应类型
+		return pgtype.UnknownOID  //未找到对应类型dumpLengthEncodedStringByEndian
 	case mysql.TypeSet:
 		return pgtype.UnknownOID  //未找到对应类型
-	case mysql.TypeTinyBlob:
+	case mysql.TypeTinyBlob, mysql.TypeMediumBlob, mysql.TypeLongBlob,mysql.TypeBlob:
 		return pgtype.ByteaOID
-	case mysql.TypeMediumBlob:
-		return pgtype.ByteaOID
-	case mysql.TypeLongBlob:
-		return pgtype.ByteaOID
-	case mysql.TypeBlob:
-		return pgtype.ByteaOID
-	case mysql.TypeVarString:
-		return pgtype.TextOID
-	case mysql.TypeString:
+	case mysql.TypeVarString, mysql.TypeString:
 		return pgtype.TextOID
 	case mysql.TypeGeometry:
 		return pgtype.UnknownOID  //未找到对应类型
@@ -2492,6 +2481,8 @@ func convertMysqlErrorToPgError(m *mysql.SQLError, te *terror.Error, sql string)
 		return handleUnknownDB(m,te,sql)
 	case 1050:
 		return handleTableExists(m,te,sql)
+	case 1051:
+		return handleUndefinedTable(m, te, sql)
 	case 1054:
 		return handleUnknownColumn(m,te, sql)
 	case 1062:
@@ -2502,8 +2493,6 @@ func convertMysqlErrorToPgError(m *mysql.SQLError, te *terror.Error, sql string)
 		return handleMultiplePKDefined(m, te, sql)
 	case 1091:
 		return handleCantDropFieldOrKey(m, te, sql)
-	case 1105:
-		return handleTypeError(m, te, sql)
 	case 1109:
 		return handleUnknownTableInDelete(m, te, sql)
 	case 1110:
@@ -2513,7 +2502,7 @@ func convertMysqlErrorToPgError(m *mysql.SQLError, te *terror.Error, sql string)
 	case 1113:
 		return handleTableNoColumn(m, te, sql)
 	case 1136:
-		return handeleColumnMisMatch(m, te,sql)
+		return handleColumnMisMatch(m, te,sql)
 	case 1138:
 		return handleInvalidUseOfNull(m, te,sql)
 	case 1142:

--- a/server/driver.go
+++ b/server/driver.go
@@ -168,7 +168,11 @@ type PreparedStatement interface {
 	// GetArgs 获取Args的具体值
 	GetArgs() []types.Datum
 
+	// GetResultFormat 获取结果返回的格式 0 为 Text, 1 为 Binary
+	GetResultFormat() []int16
 
+	// SetResultFormat 设置结果返回的格式 0 为 Text, 1 为 Binary
+	SetResultFormat(rf []int16)
 }
 
 // ResultSet is the result set of an query.

--- a/server/driver_tidb.go
+++ b/server/driver_tidb.go
@@ -81,6 +81,7 @@ type TiDBStatement struct {
 	sql         string
 	columnInfo []*ColumnInfo
 	args       []types.Datum
+	resultFormat []int16
 }
 
 // ID implements PreparedStatement ID method.
@@ -218,6 +219,16 @@ func (ts *TiDBStatement) GetArgs() []types.Datum {
 // SetArgs 进行参数绑定值
 func (ts *TiDBStatement) SetArgs(args []types.Datum) {
 	ts.args = args
+}
+
+// GetResultFormat 获取结果返回的格式 0 为 Text, 1 为 Binary
+func (ts *TiDBStatement) GetResultFormat() []int16 {
+	return ts.resultFormat
+}
+
+// SetResultFormat 设置结果返回的格式 0 为 Text, 1 为 Binary
+func (ts *TiDBStatement) SetResultFormat(rf []int16){
+	ts.resultFormat = rf
 }
 
 // OpenCtx implements IDriver.

--- a/server/handle_error.go
+++ b/server/handle_error.go
@@ -15,9 +15,9 @@ package server
 
 import (
 	"fmt"
-	"github.com/jackc/pgproto3/v2"
 	"github.com/DigitalChinaOpenSource/DCParser/mysql"
 	"github.com/DigitalChinaOpenSource/DCParser/terror"
+	"github.com/jackc/pgproto3/v2"
 	"strings"
 )
 
@@ -117,7 +117,7 @@ func handleInvalidGroupFuncUse(m *mysql.SQLError, te *terror.Error, sql string) 
 		//grouping_error
 		Code: "42803",
 		Message: pgMsg,
-		Position: int32(firstIndex + 3),
+		Position: int32(firstIndex + 1), // Add one because the first character in query string has index of 1 according to document: https://www.postgresql.org/docs/13/protocol-error-fields.html
 		Detail: "",
 		Hint: "",
 	}
@@ -146,7 +146,7 @@ func handleFiledSpecifiedTwice(m *mysql.SQLError, te *terror.Error, sql string) 
 		//duplicate_column
 		Code: "42701",
 		Message: pgMsg,
-		Position: int32(twice + 3),
+		Position: int32(twice + 1),
 		Detail: "",
 		Hint: "",
 	}
@@ -179,7 +179,7 @@ func handleUnknownTableInDelete(m *mysql.SQLError, te *terror.Error, sql string)
 	column := cutSql[ : finalLen]
 	pgMsg := fmt.Sprintf("syntax error at or near \"%s\"", column)
 
-	position := strings.Index(sql, column) + 3
+	position := strings.Index(sql, column) + 1
 
 	errorResp := &pgproto3.ErrorResponse{
 		Severity: "ERROR",
@@ -206,7 +206,7 @@ func handleCantDropFieldOrKey(m *mysql.SQLError, te *terror.Error, sql string) (
 
 	tableStart := strings.Index(strings.Trim(strings.ToUpper(sql), empty), beforeTable) + len(beforeTable)
 	cutSql := strings.Trim(sql[tableStart : ], empty)
-	tableLen := strings.Index(cutSql, empty) + 1
+	tableLen := strings.Index(cutSql, empty)
 	table := cutSql[:tableLen]
 
 	pgMsg := fmt.Sprintf("column \"%s\" of relation \"%s\" does not exist",column, table)
@@ -214,8 +214,7 @@ func handleCantDropFieldOrKey(m *mysql.SQLError, te *terror.Error, sql string) (
 	errorResp := &pgproto3.ErrorResponse{
 		Severity: "ERROR",
 		SeverityUnlocalized: "",
-		//internal_error
-		Code: "XX000",
+		Code: "42703",
 		Message: pgMsg,
 		Detail: "",
 		Hint: "",
@@ -229,13 +228,13 @@ func handleCantDropFieldOrKey(m *mysql.SQLError, te *terror.Error, sql string) (
 // eg. Multiple primary key defined
 func handleMultiplePKDefined(m *mysql.SQLError, te *terror.Error, sql string) (*pgproto3.ErrorResponse, error) {
 
-	msg, beforeTable, brackets, pk := m.Message, "TABLE ", "(", "PRIMARY KEY"
+	beforeTable, brackets, pk := "TABLE ", "(", "PRIMARY KEY"
 	tableStart := strings.Index(strings.ToUpper(sql), beforeTable) + len(beforeTable)
-	tableLen := strings.Index(sql, brackets)
-	table := msg[tableStart : tableStart + tableLen]
+	tableEnd := strings.Index(sql, brackets)
+	table := sql[tableStart :  tableEnd]
 
 	firstPKSpec := strings.Index(strings.ToUpper(sql), pk) + len(pk)
-	position := firstPKSpec + strings.Index(strings.ToUpper(sql[firstPKSpec : ]), pk)
+	position := firstPKSpec + strings.Index(strings.ToUpper(sql[firstPKSpec : ]), pk) + 1
 	pgMsg := fmt.Sprintf("multiple primary keys for table \"%s\" are not allowed", table)
 
 	errorResp := &pgproto3.ErrorResponse{
@@ -282,7 +281,7 @@ func handleParseError(m *mysql.SQLError, te *terror.Error, sql string) (*pgproto
 	pgMsg := fmt.Sprintf("syntax error at or near %s",behindNear)
 
 	// 为什么加3? 在提示信息第二行开头回提示是第几行sql的错误，他也会占偏移量，所以要将其加上。
-	position := strings.Index(sql,strings.Trim(behindNear, quotes)) + 3
+	position := strings.Index(sql,strings.Trim(behindNear, quotes)) + 1
 
 	errorResp := &pgproto3.ErrorResponse{
 		Severity: "ERROR",
@@ -309,7 +308,8 @@ func handleDuplicateKey(m *mysql.SQLError, te *terror.Error, sql string) (*pgpro
 	valueStart := strings.Index(msg, entry) + len(entry)
 	valueLen := strings.Index(msg[valueStart : ], empty)
 	value := msg[valueStart : valueStart + valueLen]
-	pgMsg := fmt.Sprintf("duplicate key value violates unique constraint \"%s\"\nDescription:  Key value %v already exists.", keyName, value)
+	pgMsg := fmt.Sprintf("duplicate key value violates unique constraint \"%s\"", keyName)
+	detailMsg := fmt.Sprintf("Key value %s already exists.", value)
 
 	errorResp := &pgproto3.ErrorResponse{
 		Severity: "ERROR",
@@ -317,7 +317,7 @@ func handleDuplicateKey(m *mysql.SQLError, te *terror.Error, sql string) (*pgpro
 		//unique_violation
 		Code: "23505",
 		Message: pgMsg,
-		Detail: "",
+		Detail: detailMsg,
 		Hint: "",
 	}
 	setFilePathAndLine(te, errorResp)
@@ -356,8 +356,10 @@ func handleUnknownColumn(m *mysql.SQLError, te *terror.Error, sql string) (*pgpr
 		relationLen := strings.Index(strings.Trim(sql[relationStart : ], empty), empty)
 		relation = sql[relationStart : relationStart + relationLen]
 		pgMsg = fmt.Sprintf("column \"%s\" of relation \"%s\" does not exist", columnName, relation)
+	} else {
+		pgMsg = m.Message
 	}
-	position := strings.Index(sql, columnName) + 3
+	position := strings.Index(sql, columnName) + 1
 
 	errorResp := &pgproto3.ErrorResponse{
 		Severity: "ERROR",
@@ -396,6 +398,32 @@ func handleTableExists(m *mysql.SQLError, te *terror.Error, sql string) (*pgprot
 
 	return errorResponse, nil
 }
+// return the name of the table from MySQL error message
+func getTableName(msg string, immediateBefore string, immediateAfter string) string {
+	tableStart := strings.Index(msg, immediateBefore) + 1
+	tableLen := strings.Index(msg[tableStart:], immediateAfter)
+	tableName := msg[tableStart : tableStart+tableLen]
+
+	return tableName
+}
+
+//handleUndefinedTable 处理表不存在的错误
+func handleUndefinedTable(m *mysql.SQLError, te *terror.Error, sql string) (*pgproto3.ErrorResponse, error) {
+	tableName := getTableName(m.Message, ".", "'")
+	pgMsg := fmt.Sprintf("table \"%s\" does not exist", tableName)
+
+	errorResponse := &pgproto3.ErrorResponse{
+		Severity: "ERROR",
+		SeverityUnlocalized: "",
+		//undefined_table
+		Code: "42P01",
+		Message: pgMsg,
+		Detail: "",
+		Hint: "",
+	}
+	setFilePathAndLine(te, errorResponse)
+	return errorResponse, nil
+}
 
 //handleUnknownDB 处理数据库不存在的错误
 // eg. Unknown database 'testDB'
@@ -403,7 +431,9 @@ func handleUnknownDB(m *mysql.SQLError, te *terror.Error, sql string) (*pgproto3
 	msg, beforeDB, apostrophe,empty := m.Message, "database ", "'"," "
 	dbStart := strings.Index(msg, beforeDB) + len(beforeDB)
 	db := strings.Trim(strings.Trim(msg[dbStart : ], empty), apostrophe)
-	pgMsg := fmt.Sprintf("database \"%s\" does not exist\nkeep last connection",db)
+	// pgsql will have another line saying "Previous connection kept" since using switch db is the same as new connection in pg
+	// We won't handle it here since its not considered part of the error message but fallback behavior of a unsuccessful new connection
+	pgMsg := fmt.Sprintf("database \"%s\" does not exist",db)
 
 	errorResp := &pgproto3.ErrorResponse{
 		Code: "3D000",
@@ -563,7 +593,7 @@ func handleDerivedMustHaveAlias(m *mysql.SQLError, te *terror.Error, sql string)
 	brackets := "("
 
 	pgMsg := "subquery in FROM must have an alias"
-	position := strings.Index(sql, brackets) + 3
+	position := strings.Index(sql, brackets) + 1
 
 	errorResp := &pgproto3.ErrorResponse{
 		Severity: "ERROR",
@@ -573,7 +603,7 @@ func handleDerivedMustHaveAlias(m *mysql.SQLError, te *terror.Error, sql string)
 		Message: pgMsg,
 		Position: int32(position),
 		Detail: "",
-		Hint: "",
+		Hint: "For example, FROM (SELECT ...) [AS] foo.",
 	}
 	setFilePathAndLine(te, errorResp)
 
@@ -683,13 +713,14 @@ func handleNoDefaultValue(m *mysql.SQLError, te *terror.Error, sql string) (*pgp
 	}else {
 		relation = sql[relationStart : relationStart + relationLen]
 	}
-	//原版pg对应错误还有一行错误信息，eg.描述:  Failing row contains (null, xxx    , null).，但是MySQL的错误信息不足以凑出第二行的信息。
+	//Can't get the second row detail message from mysql error message
+	// aka: DETAIL:  Failing row contains (1, null).
 	pgMsg := fmt.Sprintf("null value in column \"%s\" of relation \"%s\" violates not-null constraint", column, relation)
 
 	errorResp := &pgproto3.ErrorResponse{
 		Severity: "ERROR",
 		SeverityUnlocalized: "",
-		Code: "42601",
+		Code: "23502",
 		Message: pgMsg,
 		Detail: "",
 		Hint: "",
@@ -701,13 +732,13 @@ func handleNoDefaultValue(m *mysql.SQLError, te *terror.Error, sql string) (*pgp
 
 
 
-//handeleColumnMisMatch 处理字段与值的数量匹配不上的情况
-func handeleColumnMisMatch(m *mysql.SQLError, te *terror.Error, sql string) (*pgproto3.ErrorResponse, error) {
+//handleColumnMisMatch 处理字段与值的数量匹配不上的情况
+func handleColumnMisMatch(m *mysql.SQLError, te *terror.Error, sql string) (*pgproto3.ErrorResponse, error) {
 	values := "values"
 
 	valueStart := strings.Index(sql, values) + len(values)
 	//这里的游标只能指到values后面的括号，mysql的错误信息里拿不到哪些 value 是多出来的。
-	position := valueStart + 3
+	position := valueStart + 1
 	pgMsg := fmt.Sprintf("INSERT has more expressions than target columns")
 
 	errorResp := &pgproto3.ErrorResponse{
@@ -734,38 +765,12 @@ func handleRelationNotExists(m *mysql.SQLError, te *terror.Error, sql string) (*
 	nameLen := strings.Index(msg[tableNameStart : ], apostrophe)
 	tableName := msg[tableNameStart : tableNameStart + nameLen]
 	pgMsg := fmt.Sprintf("relation \"%s\" does not exist", tableName)
-	position := strings.Index(sql, tableName) + 3
+	position := strings.Index(sql, tableName) + 1
 
 	errorResp := &pgproto3.ErrorResponse{
 		Severity: "ERROR",
 		SeverityUnlocalized: "",
 		Code: "42P01",
-		Message: pgMsg,
-		Position: int32(position),
-		Detail: "",
-		Hint: "",
-	}
-	setFilePathAndLine(te, errorResp)
-
-	return errorResp,nil
-}
-// handleTypeError 处理类型转换错误信息
-func handleTypeError(m *mysql.SQLError, te *terror.Error, sql string) (*pgproto3.ErrorResponse, error) {
-	msg, quotes, beforeInput := m.Message, "\"", "parsing "
-	inputStart := strings.Index(msg, beforeInput) + len(beforeInput)
-	inputLen := strings.Index(msg[inputStart + 1 : ], quotes) + 1
-	input := msg[inputStart : inputStart + inputLen]
-	if !strings.HasSuffix(input, quotes) {
-		input += quotes
-	}
-	pgMsg := fmt.Sprintf("invalid input syntax for : %s", input)
-	position := strings.Index(sql, input)
-
-	errorResp := &pgproto3.ErrorResponse{
-		Severity: "ERROR",
-		SeverityUnlocalized: "",
-		//datatype_mismatch
-		Code: "42804",
 		Message: pgMsg,
 		Position: int32(position),
 		Detail: "",

--- a/server/handle_error_test.go
+++ b/server/handle_error_test.go
@@ -1,0 +1,566 @@
+// Copyright 2021 Digital China Group Co.,Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"context"
+	"encoding/hex"
+	"github.com/DigitalChinaOpenSource/DCParser/mysql"
+	"github.com/DigitalChinaOpenSource/DCParser/terror"
+	"github.com/jackc/pgproto3/v2"
+	. "github.com/pingcap/check"
+	"github.com/pingcap/errors"
+	"github.com/pingcap/tidb/config"
+	"github.com/pingcap/tidb/domain"
+	"github.com/pingcap/tidb/kv"
+	"github.com/pingcap/tidb/session"
+	"github.com/pingcap/tidb/store/mockstore"
+)
+
+type HandleErrorTestSuite struct {
+	dom   *domain.Domain
+	store kv.Storage
+}
+
+var _ = Suite(&HandleErrorTestSuite{})
+
+// Here is the basic info a single error conversion test needed
+type testCase struct {
+	setupSQLs           []string // a list of sql to execute to setup the error
+	triggerSQL          string   // the sql that should trigger the error
+	expectedErrorPacket string   // the hex stream dump error packet captured using pgsql
+}
+
+// Test option controls what to compare during a test
+type testOption struct {
+	compareSeverity bool
+	compareCode     bool
+	compareMessage  bool
+	compareDetail   bool
+	compareHint     bool
+	comparePosition bool
+}
+
+// default test option compares the following
+var defaultTestOption = testOption{
+	compareSeverity: true,
+	compareCode:     true,
+	compareMessage:  true,
+	compareDetail:   true,
+	compareHint:     true,
+	comparePosition: true,
+}
+
+/*
+	Skipped tests:
+	handleNoPermissionToCreateUser:		Permission module related
+	handleTableAccessDenied: 			Permission module related
+	handleColumnAccessDenied:			Permission module related
+	handleAccessDenied: 				Permission module related
+
+	handleTableNoColumn: 				Postgres allows table with no column
+
+	handleSubqueryNO1Row:				Error format is wrong since it originated from optimizer
+*/
+
+func (ts *HandleErrorTestSuite) TestHandleUndefinedTable(c *C) {
+	c.Parallel()
+	testcase := testCase{
+		setupSQLs: []string{
+			"drop table if exists testundefinedtable;",
+		},
+		triggerSQL:
+		"drop table testundefinedtable;",
+		expectedErrorPacket:
+		"4500000071534552524f5200564552524f5200433432503031004d7461626c65202274657374756e646566696e65647461626c652220646f6573206e6f7420657869737400467461626c65636d64732e63004c31323136005244726f704572726f724d73674e6f6e4578697374656e740000",
+	}
+
+	ts.testErrorConversion(c, testcase, defaultTestOption)
+}
+
+func (ts *HandleErrorTestSuite) TestHandleInvalidGroupFuncUse(c *C) {
+	c.Parallel()
+	testcase := testCase{
+		setupSQLs: []string{
+			"drop table if exists testhandleinvalidgroupfuncuse;",
+			"create table testhandleinvalidgroupfuncuse(a int);",
+		},
+		triggerSQL:
+		"select * from testhandleinvalidgroupfuncuse where sum(a) > 1000;",
+		expectedErrorPacket:
+		"450000007f534552524f5200564552524f5200433432383033004d6167677265676174652066756e6374696f6e7320617265206e6f7420616c6c6f77656420696e20574845524500503531004670617273655f6167672e63004c3537360052636865636b5f6167676c6576656c735f616e645f636f6e73747261696e74730000",
+	}
+
+	ts.testErrorConversion(c, testcase, defaultTestOption)
+}
+
+func (ts *HandleErrorTestSuite) TestHandleFiledSpecifiedTwice(c *C) {
+	c.Parallel()
+	testcase := testCase{
+		setupSQLs: []string{
+			"drop table if exists testfieldspecifiedtwice;",
+			"create table testfieldspecifiedtwice(a int);",
+		},
+		triggerSQL:
+		"insert into testfieldspecifiedtwice(a, a) values(10, 10);",
+		expectedErrorPacket:
+		"450000006d534552524f5200564552524f5200433432373031004d636f6c756d6e2022612220737065636966696564206d6f7265207468616e206f6e636500503430004670617273655f7461726765742e63004c313035340052636865636b496e73657274546172676574730000",
+	}
+
+	ts.testErrorConversion(c, testcase, defaultTestOption)
+}
+
+func (ts *HandleErrorTestSuite) TestHandleUnknownTableInDelete(c *C) {
+	c.Parallel()
+	testcase := testCase{
+		setupSQLs: []string{
+			"drop table if exists test_table;",
+			"create table test_table(a int);",
+		},
+		triggerSQL:
+		"delete a from test_table;",
+		expectedErrorPacket:
+		"4500000059534552524f5200564552524f5200433432363031004d73796e746178206572726f72206174206f72206e6561722022612200503800467363616e2e6c004c3131383000527363616e6e65725f79796572726f720000",
+	}
+
+	ts.testErrorConversion(c, testcase, defaultTestOption)
+}
+
+func (ts *HandleErrorTestSuite) TestHandleCantDropFieldOrKey(c *C) {
+	c.Parallel()
+	testcase := testCase{
+		setupSQLs: []string{
+			"drop table if exists test_table;",
+			"create table test_table(a int);",
+		},
+		triggerSQL:
+		"alter table test_table drop column b;",
+		expectedErrorPacket:
+		"4500000073534552524f5200564552524f5200433432373033004d636f6c756d6e20226222206f662072656c6174696f6e2022746573745f7461626c652220646f6573206e6f7420657869737400467461626c65636d64732e63004c37373930005241544578656344726f70436f6c756d6e0000",
+	}
+
+	ts.testErrorConversion(c, testcase, defaultTestOption)
+}
+
+func (ts *HandleErrorTestSuite) TestHandleMultiplePKDefined(c *C) {
+	c.Parallel()
+	testcase := testCase{
+		setupSQLs: []string{
+			"drop table if exists test_table;",
+		},
+		triggerSQL:
+		"create table test_table(a int primary key, b int primary key);",
+		expectedErrorPacket:
+		"450000008d534552524f5200564552524f5200433432503136004d6d756c7469706c65207072696d617279206b65797320666f72207461626c652022746573745f7461626c652220617265206e6f7420616c6c6f77656400503530004670617273655f7574696c636d642e63004c3231333300527472616e73666f726d496e646578436f6e73747261696e740000",
+	}
+
+	ts.testErrorConversion(c, testcase, defaultTestOption)
+}
+
+func (ts *HandleErrorTestSuite) TestHandleParseError(c *C) {
+	c.Parallel()
+	testcase := testCase{
+		setupSQLs: []string{
+			"drop table if exists test_table;",
+		},
+		triggerSQL:
+		"creat table test_table(a int);", //create spelled wrong intentionally
+		expectedErrorPacket:
+		"450000005d534552524f5200564552524f5200433432363031004d73796e746178206572726f72206174206f72206e656172202263726561742200503100467363616e2e6c004c3131383000527363616e6e65725f79796572726f720000",
+	}
+
+	ts.testErrorConversion(c, testcase, defaultTestOption)
+}
+
+func (ts *HandleErrorTestSuite) TestHandleDuplicateKey(c *C) {
+	c.Parallel()
+	testcase := testCase{
+		setupSQLs: []string{
+			"drop table if exists test_table;",
+			"create table test_table(a int, primary key (a));",
+			"insert into test_table values(1);",
+		},
+		triggerSQL:
+		"insert into test_table values(1);",
+		expectedErrorPacket:
+		"45000000c2534552524f5200564552524f5200433233353035004d6475706c6963617465206b65792076616c75652076696f6c6174657320756e6971756520636f6e73747261696e742022746573745f7461626c655f706b65792200444b6579202861293d28312920616c7265616479206578697374732e00737075626c69630074746573745f7461626c65006e746573745f7461626c655f706b657900466e6274696e736572742e63004c36353600525f62745f636865636b5f756e697175650000",
+	}
+
+	noMessageDetail := testOption{
+		compareSeverity: true,
+		compareCode:     true,
+		compareMessage:  false,
+		compareDetail:   false,
+		compareHint:     true,
+		comparePosition: true,
+	}
+
+	ts.testErrorConversion(c, testcase, noMessageDetail)
+}
+
+func (ts *HandleErrorTestSuite) TestHandleUnknownColumn(c *C) {
+	c.Parallel()
+	testcase := testCase{
+		setupSQLs: []string{
+			"drop table if exists test_table;",
+			"create table test_table(a int);",
+		},
+		triggerSQL:
+		"insert into test_table(bbb) values(1);",
+		expectedErrorPacket:
+		"450000007e534552524f5200564552524f5200433432373033004d636f6c756d6e202262626222206f662072656c6174696f6e2022746573745f7461626c652220646f6573206e6f7420657869737400503234004670617273655f7461726765742e63004c313033390052636865636b496e73657274546172676574730000",
+	}
+
+	ts.testErrorConversion(c, testcase, defaultTestOption)
+}
+
+func (ts *HandleErrorTestSuite) TestHandleTableExists(c *C) {
+	c.Parallel()
+	testcase := testCase{
+		setupSQLs: []string{
+			"drop table if exists test_table;",
+			"create table test_table(a int);",
+		},
+		triggerSQL:
+		"create table test_table(a int);",
+		expectedErrorPacket:
+		"4500000068534552524f5200564552524f5200433432503037004d72656c6174696f6e2022746573745f7461626c652220616c7265616479206578697374730046686561702e63004c313136340052686561705f6372656174655f776974685f636174616c6f670000",
+	}
+
+	ts.testErrorConversion(c, testcase, defaultTestOption)
+}
+func (ts *HandleErrorTestSuite) TestHandleUnknownDB(c *C) {
+	c.Parallel()
+	testcase := testCase{
+		setupSQLs: []string{
+			"drop database if exists test_db;",
+		},
+		triggerSQL:
+		"use test_db;",
+		expectedErrorPacket:
+		"450000005c53464154414c0056464154414c00433344303030004d64617461626173652022746573745f64622220646f6573206e6f742065786973740046706f7374696e69742e63004c3837370052496e6974506f7374677265730000",
+	}
+
+	ts.testErrorConversion(c, testcase, defaultTestOption)
+}
+
+func (ts *HandleErrorTestSuite) TestHandleDropDBFail(c *C) {
+	c.Parallel()
+	testcase := testCase{
+		setupSQLs: []string{
+			"drop database if exists test_db;",
+		},
+		triggerSQL:
+		"drop database test_db;",
+		expectedErrorPacket:
+		"4500000058534552524f5200564552524f5200433344303030004d64617461626173652022746573745f64622220646f6573206e6f7420657869737400466462636f6d6d616e64732e63004c383431005264726f7064620000",
+	}
+
+	ts.testErrorConversion(c, testcase, defaultTestOption)
+}
+func (ts *HandleErrorTestSuite) TestHandleCreateDBFail(c *C) {
+	c.Parallel()
+	testcase := testCase{
+		setupSQLs: []string{
+			"drop database if exists test_db;",
+			"create database test_db;",
+		},
+		triggerSQL:
+		"create database test_db;",
+		expectedErrorPacket:
+		"450000005a534552524f5200564552524f5200433432503034004d64617461626173652022746573745f64622220616c72656164792065786973747300466462636f6d6d616e64732e63004c353132005263726561746564620000",
+	}
+
+	ts.testErrorConversion(c, testcase, defaultTestOption)
+}
+
+
+func (ts *HandleErrorTestSuite) TestHandleDataOutOfRange(c *C) {
+	c.Parallel()
+	testcase := testCase{
+		setupSQLs: []string{
+			"drop table if exists test_table;",
+			"create table test_table(a int);",
+		},
+		triggerSQL:
+		"insert into test_table values(2147483647 + 1);", //max for signed INT + 1
+		expectedErrorPacket:
+		"4500000044534552524f5200564552524f5200433232303033004d696e7465676572206f7574206f662072616e67650046696e742e63004c3738310052696e7434706c0000",
+	}
+
+	// We won't be able to get detailed column information from mysql error message, so we won't compare them
+	//... obtained string = "column 'a' value out of range"
+	//... expected string = "integer out of range"
+
+	noMessage := testOption{
+		compareSeverity: true,
+		compareCode:     true,
+		compareMessage:  false,
+		compareDetail:   true,
+		compareHint:     true,
+		comparePosition: true,
+	}
+	ts.testErrorConversion(c, testcase, noMessage)
+}
+
+func (ts *HandleErrorTestSuite) TestHandleDataTooLong(c *C) {
+	c.Parallel()
+	testcase := testCase{
+		setupSQLs: []string{
+			"drop table if exists test_table;",
+			"create table test_table(a bit(3));", // don't use char type to test this, it will result in stirng right truncation error, error code 22001
+		},
+		triggerSQL:
+		"insert into test_table values('1000000');",
+		expectedErrorPacket:
+		"450000005e534552524f5200564552524f5200433232303236004d62697420737472696e67206c656e677468203720646f6573206e6f74206d6174636820747970652062697428332900467661726269742e63004c34303600526269740000",
+	}
+
+	noMessage := testOption{
+		compareSeverity: true,
+		compareCode:     true,
+		compareMessage:  false,
+		compareDetail:   true,
+		compareHint:     true,
+		comparePosition: true,
+	}
+	ts.testErrorConversion(c, testcase, noMessage)
+}
+
+func (ts *HandleErrorTestSuite) TestHandleWrongNumberOfColsInSelect(c *C) {
+	c.Parallel()
+	testcase := testCase{
+		setupSQLs: []string{
+			"drop table if exists test_table;",
+			"drop table if exists test_table2;",
+			"create table test_table(a int);",
+			"create table test_table2(a int, b int);",
+		},
+		triggerSQL:
+		"select * from test_table UNION select * from test_table2;",
+		expectedErrorPacket:
+		"4500000081534552524f5200564552524f5200433432363031004d6561636820554e494f4e207175657279206d7573742068617665207468652073616d65206e756d626572206f6620636f6c756d6e73005033390046616e616c797a652e63004c3230303700527472616e73666f726d5365744f7065726174696f6e547265650000",
+	}
+
+	noPosition := testOption{
+		compareSeverity: true,
+		compareCode:     true,
+		compareMessage:  true,
+		compareDetail:   true,
+		compareHint:     true,
+		comparePosition: false,
+	}
+
+	ts.testErrorConversion(c, testcase, noPosition)
+}
+func (ts *HandleErrorTestSuite) TestHandleDerivedMustHaveAlias(c *C) {
+	c.Parallel()
+	testcase := testCase{
+		setupSQLs: []string{
+			"drop table if exists test_table;",
+			"create table test_table(a int);",
+		},
+		triggerSQL:
+		"select * from (select * from test_table);",
+		expectedErrorPacket:
+		"450000008a534552524f5200564552524f5200433432363031004d737562717565727920696e2046524f4d206d757374206861766520616e20616c6961730048466f72206578616d706c652c2046524f4d202853454c454354202e2e2e29205b41535d20666f6f2e0050313500466772616d2e79004c31323131350052626173655f797970617273650000",
+	}
+
+	ts.testErrorConversion(c, testcase, defaultTestOption)
+}
+
+//func (ts *HandleErrorTestSuite) TestHandleSubqueryNo1Row(c *C) {
+//	c.Parallel()
+//	testcase := testCase{
+//		setupSQLs: []string{
+//			"drop table if exists test_table;",
+//			"create table test_table(a int);",
+//			"insert into test_table values(1);",
+//			"insert into test_table values(2);",
+//		},
+//		triggerSQL:
+//		"select * from test_table where a = (select a from test_table);",
+//		expectedErrorPacket:
+//		"4500000081534552524f5200564552524f5200433231303030004d6d6f7265207468616e206f6e6520726f772072657475726e65642062792061207375627175657279207573656420617320616e2065787072657373696f6e00466e6f6465537562706c616e2e63004c31313539005245786563536574506172616d506c616e0000",
+//	}
+//
+//	ts.testErrorConversion(c, testcase, defaultTestOption)
+//}
+
+func (ts *HandleErrorTestSuite) TestHandleNoDefaultValue(c *C) {
+	c.Parallel()
+	testcase := testCase{
+		setupSQLs: []string{
+			"drop table if exists test_table;",
+			"create table test_table(a int, b varchar(1) not null);",
+		},
+		triggerSQL:
+		"insert into test_table(a) values (1);",
+		expectedErrorPacket:
+		"45000000c5534552524f5200564552524f5200433233353032004d6e756c6c2076616c756520696e20636f6c756d6e20226222206f662072656c6174696f6e2022746573745f7461626c65222076696f6c61746573206e6f742d6e756c6c20636f6e73747261696e7400444661696c696e6720726f7720636f6e7461696e732028312c206e756c6c292e00737075626c69630074746573745f7461626c650063620046657865634d61696e2e63004c31393533005245786563436f6e73747261696e74730000",
+	}
+	// Can't get the second row detail message from mysql error message
+	// aka: DETAIL:  Failing row contains (1, null).
+	// So we wont compare detail
+	noDetail := testOption{
+		compareSeverity: true,
+		compareCode:     true,
+		compareMessage:  true,
+		compareDetail:   false,
+		compareHint:     true,
+		comparePosition: true,
+	}
+	ts.testErrorConversion(c, testcase, noDetail)
+}
+
+func (ts *HandleErrorTestSuite) TestHandleColumnMisMatch(c *C) {
+	c.Parallel()
+	testcase := testCase{
+		setupSQLs: []string{
+			"drop table if exists test_table;",
+			"create table test_table(a int);",
+		},
+		triggerSQL:
+		"insert into test_table values (1,2);",
+		expectedErrorPacket:
+		"4500000073534552524f5200564552524f5200433432363031004d494e5345525420686173206d6f72652065787072657373696f6e73207468616e2074617267657420636f6c756d6e73005033340046616e616c797a652e63004c39303700527472616e73666f726d496e73657274526f770000",
+	}
+
+	// We won't be able to get info about which column mismatched from mysql error, so we will skip comparing position
+	noPosition := testOption{
+		compareSeverity: true,
+		compareCode:     true,
+		compareMessage:  true,
+		compareDetail:   true,
+		compareHint:     true,
+		comparePosition: false,
+	}
+	ts.testErrorConversion(c, testcase, noPosition)
+}
+
+func (ts *HandleErrorTestSuite) TestHandleRelationNotExists(c *C) {
+	c.Parallel()
+	testcase := testCase{
+		setupSQLs: []string{
+			"drop table if exists test_table;",
+		},
+		triggerSQL:
+		"insert into test_table values(1);",
+		expectedErrorPacket:
+		"450000006d534552524f5200564552524f5200433432503031004d72656c6174696f6e2022746573745f7461626c652220646f6573206e6f7420657869737400503133004670617273655f72656c6174696f6e2e63004c3133373600527061727365724f70656e5461626c650000",
+	}
+
+	ts.testErrorConversion(c, testcase, defaultTestOption)
+}
+
+// testErrorConversion does the actual comparison, will be called by the various tests
+func (ts *HandleErrorTestSuite) testErrorConversion(c *C, inputCase testCase, option testOption) {
+	store, err := mockstore.NewMockTikvStore()
+	c.Assert(err, IsNil)
+	defer store.Close()
+	dom, err := session.BootstrapSession(store)
+	c.Assert(err, IsNil)
+	defer dom.Close()
+
+	se, err := session.CreateSession4Test(store)
+	c.Assert(err, IsNil)
+	_, err = se.Execute(context.Background(), "use test")
+	c.Assert(err, IsNil)
+
+	tidbdrv := NewTiDBDriver(ts.store)
+	cfg := config.NewConfig()
+	cfg.Port = 0
+	cfg.Status.ReportStatus = false
+	server, err := NewServer(cfg, tidbdrv)
+
+	c.Assert(err, IsNil)
+	defer server.Close()
+
+	// execute the setup SQLs
+	for _, setupSQL := range inputCase.setupSQLs {
+		_, err = se.Execute(context.Background(), setupSQL)
+		c.Assert(err, IsNil) //error must be nil during setup
+	}
+
+	// execute the trigger SQL
+	_, err = se.Execute(context.Background(), inputCase.triggerSQL)
+
+	compareError := sameError(inputCase.triggerSQL, err, inputCase.expectedErrorPacket, option, c)
+	c.Assert(compareError, IsNil) // error during comparison must be nil
+}
+
+// sameError compare if the tidb error converts to the expected errorPacket captured from pgsql
+func sameError(sql string, tidbError error, expectedErrorPacket string, option testOption, c *C) error {
+	m, te := unpackError(tidbError)
+	convertedPGError, err := convertMysqlErrorToPgError(m, te, sql)
+	if err != nil {
+		return err
+	}
+
+	expectedPGError := &pgproto3.ErrorResponse{}
+	// convert the hex stream to byte stream
+	expected, _ := hex.DecodeString(expectedErrorPacket)
+	// remove the first 5 bytes: 4bytes for error, 1 bytes for length
+	expected = expected[5:]
+	err = expectedPGError.Decode(expected)
+	if err != nil {
+		return err
+	}
+	samePGError(convertedPGError, expectedPGError, option, c)
+	return nil
+}
+
+// unpackError unpack a wrapped error into a mysql error and a terror.error
+func unpackError(e error) (*mysql.SQLError, *terror.Error) {
+	var (
+		m  *mysql.SQLError
+		te *terror.Error
+		ok bool
+	)
+	originErr := errors.Cause(e)
+	if te, ok = originErr.(*terror.Error); ok {
+		m = terror.ToSQLError(te)
+	} else {
+		e := errors.Cause(originErr)
+		switch y := e.(type) {
+		case *terror.Error:
+			m = terror.ToSQLError(y)
+		default:
+			m = mysql.NewErrf(mysql.ErrUnknown, "%s", nil, e.Error())
+		}
+	}
+	return m, te
+}
+
+// samePGError will check if two pgproto3 Error response are functionally the same according to the test option given
+func samePGError(e1, e2 *pgproto3.ErrorResponse, option testOption, c *C) {
+	if option.compareSeverity {
+		c.Assert(e1.Severity, DeepEquals, e2.Severity)
+	}
+	if option.compareCode {
+		c.Assert(e1.Code, DeepEquals, e2.Code)
+	}
+	if option.compareMessage {
+		c.Assert(e1.Message, DeepEquals, e2.Message)
+	}
+	if option.compareDetail {
+		c.Assert(e1.Detail, DeepEquals, e2.Detail)
+	}
+	if option.compareHint {
+		c.Assert(e1.Hint, DeepEquals, e2.Hint)
+	}
+	if option.comparePosition {
+		c.Assert(e1.Position, Equals, e2.Position)
+	}
+}


### PR DESCRIPTION
### What problem does this PR solve?

The TiDB original Unit Tests were designed for MySQL's protocol, we have to change almost all of them in order to make it applicable to PostgreSQL's protocol.

In addition to fixing Unit Tests, his PR also brings better compatibility with PostgreSQL's data types, error handling and connection procedures.

### What is changed and how it works?

What's Changed:

- Fixed Unit Test for handshake and simple query dispatch under server/conn.go
- Added New Unit Test Suite for error handler that converts MySQL error to PG error
- Fixed Some Unit Tests within Executor module, mostly prepared statement related
- Fixed Unit Test related to the initial database info schema
- Multiple bug fixes, mostly around where new Unit Test is written 


### Tests 

TiDB for PostgreSQL is now capable of passing most of the Unit tests inside server module, and some tests inside executor module. We are still working on fixing more Unit Tests and bugs
