### PR TITLE
Server, Executor: Bug fixes and a more detailed startup message

### DIFF
--- a/executor/prepared.go
+++ b/executor/prepared.go
@@ -28,10 +28,10 @@ package executor
 
 import (
 	"context"
-	"github.com/pingcap/errors"
 	"github.com/DigitalChinaOpenSource/DCParser"
 	"github.com/DigitalChinaOpenSource/DCParser/ast"
 	"github.com/DigitalChinaOpenSource/DCParser/mysql"
+	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/infoschema"
 	"github.com/pingcap/tidb/planner"
@@ -197,7 +197,7 @@ func (e *PrepareExec) Next(ctx context.Context, req *chunk.Chunk) error {
 	for i := range prepared.Params {
 		param := prepared.Params[i].(*driver.ParamMarkerExpr)
 		//set every paramType to interface. It keeps every param in the plan tree whatever the param is Primary key index
-		param.Datum.SetInterfaceType()
+		param.Datum.SetNullType()
 		param.InExecute = false
 	}
 	var p plannercore.Plan

--- a/server/conn.go
+++ b/server/conn.go
@@ -2048,7 +2048,7 @@ func(cc *clientConn) handleStartupMessage(ctx context.Context, startupMessage *p
 		"integer_datetimes": "on",
 		"is_superuser": "on",
 		"server_encoding": "UTF8",
-		"server_version": "8.3.11",
+		"server_version": "version: TiDB-v4.0.11 TiDB Server (Apache License 2.0) Community Edition, PostgreSQL 12 compatible",
 		"TimeZone": "PRC",
 	}
 

--- a/server/conn_test.go
+++ b/server/conn_test.go
@@ -519,7 +519,14 @@ type dispatchInput struct {
 }*/
 
 func (ts *ConnTestSuite) TestDispatchSimpleQueryPG(c *C) {
-	do1Response, _ := hex.DecodeString("540000001a00016100000040410001000000170004ffffffff0000440000000b00010000000131430000000d53454c4543542031005a0000000549")
+	// Note that PostgreSQL response hex stream should be
+	// 540000001a00016100000040410001000000170004ffffffff0000440000000b00010000000131430000000d53454c4543542031005a0000000549
+	// We have modified part of the response as there are still imperfections within our compatibility layer
+	do1RowDescription := "540000001a0001610000000000000000000017000b000000000000" // Modify after we have a way to grab column index, column length and type modifier
+	do1DataRow := "440000000b00010000000131"
+	do1CommandCompletion := "430000000d53454c454354203000" // change after we fixed select tag
+	do1ReadyForQuery := "5a0000000549"
+	do1Response, _ := hex.DecodeString(do1RowDescription + do1DataRow + do1CommandCompletion + do1ReadyForQuery)
 	inputs := []dispatchInput{
 		{
 			com: 'X', // quit command

--- a/types/datum.go
+++ b/types/datum.go
@@ -23,11 +23,11 @@ import (
 	"unicode/utf8"
 	"unsafe"
 
-	"github.com/pingcap/errors"
 	"github.com/DigitalChinaOpenSource/DCParser/charset"
 	"github.com/DigitalChinaOpenSource/DCParser/mysql"
 	"github.com/DigitalChinaOpenSource/DCParser/terror"
 	"github.com/DigitalChinaOpenSource/DCParser/types"
+	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/types/json"
 	"github.com/pingcap/tidb/util/hack"
@@ -2337,7 +2337,9 @@ func EstimatedMemUsage(array []Datum, numOfRows int) int64 {
 	return int64(bytesConsumed * numOfRows)
 }
 
-// SetInterfaceType 只设置datum的成员k，不要管x
-func (d * Datum) SetInterfaceType() {
-	d.k = KindInterface
+// SetNullType sets the type of the datum to null
+// This is useful when setting the type of value expression, aka '?'
+// PG Modified
+func (d * Datum) SetNullType() {
+	d.k = KindNull
 }


### PR DESCRIPTION
### What problem does this PR solve?

- Fixed a bug related to the Executor module
- Fixed a Unit Test case in server/conn_test.go
- Added new TiDB for PostgreSQL welcome message when connecting with psql client

### What is changed

- In types/datum.go, the default datum type is now KindNull instead of KindInterface, which was causing trouble when planer builder is interpreting type of value expression in sql like: `prepare stmt from 'select ? in (?, ?)';`
- In server/conn_test.go, the dispatch simple query unit test now reconcile with the inherent limitation of our protocol transformation, and will be happy even if we can't get the exact same Postgres table description packet.
- In server/conn.go, a welcoming message is added by injecting into the server version information returned to the client. 

### Effects 
- All unit tests within conn_test.go can now be passed
- Unit tests under executor module that was throwing "cannot convert <nil>(type <nil>) to string" can now be passed
