### PR TITLE
Owner: Remove connection file created during fail_test.go

### DIFF
--- a/owner/fail_test.go
+++ b/owner/fail_test.go
@@ -59,6 +59,7 @@ var (
 )
 
 func (s *testSuite) TestFailNewSession(c *C) {
+	os.Remove("new_session:12379")
 	ln, err := net.Listen("unix", "new_session:12379")
 	c.Assert(err, IsNil)
 	srv := grpc.NewServer(grpc.ConnectionTimeout(time.Minute))


### PR DESCRIPTION
Signed-off-by: David <davidyangad@gmail.com>

### What problem does this PR solve?

Un-removed unix domain socket file cause address in-use error
