### PR TITLE
core: add the implemet of setparamtype at show, showddl, datasource, limit plan ; executor: add new case 'LogicalLimit' at Next()

### DIFF
--- a/executor/prepared.go
+++ b/executor/prepared.go
@@ -220,6 +220,8 @@ func (e *PrepareExec) Next(ctx context.Context, req *chunk.Chunk) error {
 		err = SetUpdateParamType(p.(*plannercore.Update), &prepared.Params)
 	case *plannercore.LogicalSort:
 		err = SetSortType(p.(*plannercore.LogicalSort), &prepared.Params)
+	case *plannercore.LogicalLimit:
+		err = SetLimitType(p.(*plannercore.LogicalLimit), &prepared.Params)
 	}
 	if err != nil {
 		return err
@@ -395,6 +397,11 @@ func SetUpdateParamTypes(assignmnet *expression.Assignment, paramExprs *[]ast.Pa
 // SetSortType 从根节点计划是logicalSort的计划中获取参数类型
 func SetSortType(sort *plannercore.LogicalSort, i *[]ast.ParamMarkerExpr) error {
 	return sort.SetParamType(i)
+}
+
+// SetLimitType set the parameter type of limit plan
+func SetLimitType(limit *plannercore.LogicalLimit, i *[]ast.ParamMarkerExpr) error {
+	return limit.SetParamType(i)
 }
 
 // ExecuteExec represents an EXECUTE executor.

--- a/planner/core/logical_plans.go
+++ b/planner/core/logical_plans.go
@@ -1099,8 +1099,17 @@ type LogicalLimit struct {
 	limitHints limitHintInfo
 }
 
-// SetParamType todo 设置参数类型
-func (p *LogicalLimit) SetParamType(paramExprs *[]ast.ParamMarkerExpr) (err error) {
+// SetParamType set the parameter type of logicalLimit plan
+// when send "limit $1 offset $2",planbuilder will convert it to a tableDual plan.see why at /planner/core/logical_plan_builder.go buildLimit
+func (ll *LogicalLimit) SetParamType(paramExprs *[]ast.ParamMarkerExpr) (err error) {
+	if childs := ll.children; childs != nil {
+		for _, child := range childs {
+			err = child.SetParamType(paramExprs)
+			if err != nil {
+				return err
+			}
+		}
+	}
 	return err
 }
 

--- a/planner/core/logical_plans.go
+++ b/planner/core/logical_plans.go
@@ -611,7 +611,8 @@ type DataSource struct {
 	isForUpdateRead bool
 }
 
-// SetParamType todo 设置参数类型
+// SetParamType set the parameter type of dataSource plan
+// dataSource plan is always the last node of o plan tree and it will not contain any parameter.Just return nil
 func (ds *DataSource) SetParamType(paramExprs *[]ast.ParamMarkerExpr) (err error) {
 	return err
 }
@@ -1240,7 +1241,11 @@ type LogicalShow struct {
 	ShowContents
 }
 
-// SetParamType todo 设置参数类型
+// SetParamType set the parameter type of logicalShow plan
+// https://www.postgresql.org/docs/current/sql-show.html
+// According to the postgresql document, any parameter won't follow the show statement.
+// Besides, show statement won't be the sub statement of any other sql statement.
+// So, Show statement doesn't need actual implement. Just return nil.
 func (p *LogicalShow) SetParamType(paramExprs *[]ast.ParamMarkerExpr) (err error) {
 	return err
 }
@@ -1252,7 +1257,10 @@ type LogicalShowDDLJobs struct {
 	JobNumber int64
 }
 
-// SetParamType todo 设置参数类型
+// SetParamType set the parameter type of logicalShowDDLJobs plan
+// https://www.postgresql.org/docs/current/sql-show.html
+// Actually, postgresql doesn't support the syntax like "show create table tname"
+// And showddl statement won't contain parameter. Just return nil
 func (p *LogicalShowDDLJobs) SetParamType(paramExprs *[]ast.ParamMarkerExpr) (err error) {
 	return err
 }

--- a/planner/core/physical_plans.go
+++ b/planner/core/physical_plans.go
@@ -916,8 +916,11 @@ type PhysicalShow struct {
 	ShowContents
 }
 
-// SetParamType set the parameter type in ParamMarkerExpr from PhysicalShow
-// todo 从PhysicalShow计划中获取参数类型
+// SetParamType set the parameter type of physicalShow plan
+// https://www.postgresql.org/docs/current/sql-show.html
+// According to the postgresql document, any parameter won't follow the show statement.
+// Besides, show statement won't be the sub statement of any other sql statement.
+// So, Show statement doesn't need actual implement. Just return nil.
 func (show *PhysicalShow) SetParamType(paramExprs *[]ast.ParamMarkerExpr) (err error) {
 	return err
 }
@@ -929,8 +932,10 @@ type PhysicalShowDDLJobs struct {
 	JobNumber int64
 }
 
-// SetParamType set the parameter type in ParamMarkerExpr from PhysicalShowDDLJobs
-// todo 从PhysicalShowDDLJobs中获取参数类型
+// SetParamType set the parameter type of physicalShowDDLJobs plan
+// https://www.postgresql.org/docs/current/sql-show.html
+// Actually, postgresql doesn't support the syntax like "show create table tname"
+// And showddl statement won't contain parameter. Just return nil
 func (ddl *PhysicalShowDDLJobs) SetParamType(paramExprs *[]ast.ParamMarkerExpr) (err error) {
 	return err
 }


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #28

Problem Summary

some interface have not be implemented，so some sql statement can't get parameter type。

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed: 
 
New implement method 'setparamtype' at show ,showddl, datasource, limit plan

How it Works:

set the parameter type from the plan tree

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->
