### PR TITLE
Add returning keyword plan and executor for supporting PG compliant DML

### DIFF
--- a/executor/returning.go
+++ b/executor/returning.go
@@ -1,0 +1,98 @@
+// Copyright 2021 Digital China Group Co.,Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package executor
+
+import (
+	"context"
+	"runtime/trace"
+	"time"
+
+	"github.com/pingcap/tidb/expression"
+	"github.com/pingcap/tidb/util/chunk"
+	"github.com/pingcap/tidb/util/execdetails"
+)
+
+type ReturningExec struct {
+	baseExecutor
+
+	Idx     int
+	fetched bool
+	schema  *expression.Schema
+
+	ResultSet *recordSet
+}
+
+func (e *ReturningExec) Open(ctx context.Context) error {
+
+	return e.children[0].Open(ctx)
+}
+
+func (e *ReturningExec) Next(ctx context.Context, req *chunk.Chunk) error {
+	return e.fetchRowChunks(ctx)
+}
+
+func (e *ReturningExec) Close() error {
+	return e.children[0].Close()
+}
+
+func (e *ReturningExec) fetchRowChunks(ctx context.Context) error {
+	defer func() {
+		e.fetched = true
+	}()
+
+	var stmtDetail *execdetails.StmtExecDetails
+	stmtDetailRaw := ctx.Value(execdetails.StmtExecDetailKey)
+	if stmtDetailRaw != nil {
+		stmtDetail = stmtDetailRaw.(*execdetails.StmtExecDetails)
+	}
+
+	rs := &recordSet{
+		executor: e.base().children[0],
+	}
+
+	rs.rows = make([]chunk.Row, 0, 1024)
+
+	for {
+		req := rs.NewChunk()
+		// Here server.tidbResultSet implements Next method.
+		err := rs.Next(ctx, req)
+		if err != nil {
+			return err
+		}
+
+		rowCount := req.NumRows()
+		if rowCount == 0 {
+			break
+		}
+		start := time.Now()
+		reg := trace.StartRegion(ctx, "ProcessReturning")
+
+		for i := 0; i < rowCount; i++ {
+			row := req.GetRow(i)
+
+			row.IsNull(0)
+
+			rs.rows = append(rs.rows, row)
+		}
+
+		if stmtDetail != nil {
+			stmtDetail.WriteSQLRespDuration += time.Since(start)
+		}
+		reg.End()
+	}
+
+	e.ResultSet = rs
+
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/pingcap/tidb
 require (
 	cloud.google.com/go v0.51.0 // indirect
 	github.com/BurntSushi/toml v0.3.1
-	github.com/DigitalChinaOpenSource/DCParser v0.0.0-20210628023842-8b1d530491a5
+	github.com/DigitalChinaOpenSource/DCParser v0.0.0-20210825054110-e3314361a5f0
 	github.com/DigitalChinaOpenSource/dcbr v4.0.11+incompatible
 	github.com/Jeffail/gabs/v2 v2.5.1
 	github.com/aws/aws-sdk-go v1.30.24 // indirect
@@ -30,6 +30,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway v1.14.3 // indirect
 	github.com/iancoleman/strcase v0.0.0-20191112232945-16388991a334
 	github.com/jackc/pgio v1.0.0
+	github.com/jackc/pgproto3 v1.1.0
 	github.com/jackc/pgproto3/v2 v2.0.7
 	github.com/jackc/pgtype v1.6.2
 	github.com/klauspost/cpuid v1.2.1
@@ -53,6 +54,7 @@ require (
 	github.com/pingcap/sysutil v0.0.0-20201130064824-f0c8aa6a6966
 	github.com/pingcap/tidb-tools v4.0.9-0.20201127090955-2707c97b3853+incompatible
 	github.com/pingcap/tipb v0.0.0-20200618092958-4fad48b4c8c3
+	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.5.1
 	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -25,6 +25,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DigitalChinaOpenSource/DCParser v0.0.0-20210628023842-8b1d530491a5 h1:E8nid1A2Qc/S7paFlGgPw3YBliLVNI0PxTOffdShCk8=
 github.com/DigitalChinaOpenSource/DCParser v0.0.0-20210628023842-8b1d530491a5/go.mod h1:3n404SkCabBM0pYRgCyXEKttOLdrmMyBaWMGvaRs/ns=
+github.com/DigitalChinaOpenSource/DCParser v0.0.0-20210825054110-e3314361a5f0 h1:aEmZRULTRVMA8bsu0XiiJslCmuhVwef92nLK+2XZqcM=
+github.com/DigitalChinaOpenSource/DCParser v0.0.0-20210825054110-e3314361a5f0/go.mod h1:3n404SkCabBM0pYRgCyXEKttOLdrmMyBaWMGvaRs/ns=
 github.com/DigitalChinaOpenSource/dcbr v4.0.11+incompatible h1:ICQTYSnJC7i3Ns4xXGS5DMi1wTfg44woW4eWQi2ZNTQ=
 github.com/DigitalChinaOpenSource/dcbr v4.0.11+incompatible/go.mod h1:sIm2Eayjb84BFeHrWkkA+4Zdt+4CRSs1HhrlosPwRNk=
 github.com/Jeffail/gabs/v2 v2.5.1 h1:ANfZYjpMlfTTKebycu4X1AgkVWumFVDYQl7JwOr4mDk=

--- a/planner/core/common_plans.go
+++ b/planner/core/common_plans.go
@@ -750,6 +750,8 @@ type Delete struct {
 
 	SelectPlan PhysicalPlan
 
+	ReturningPlan PhysicalPlan
+
 	TblColPosInfos TblColPosInfoSlice
 }
 

--- a/planner/core/exhaust_physical_plans.go
+++ b/planner/core/exhaust_physical_plans.go
@@ -2109,3 +2109,12 @@ func (p *LogicalMaxOneRow) exhaustPhysicalPlans(prop *property.PhysicalProperty)
 	mor := PhysicalMaxOneRow{}.Init(p.ctx, p.stats, p.blockOffset, &property.PhysicalProperty{ExpectedCnt: 2})
 	return []PhysicalPlan{mor}, true
 }
+
+func (p *LogicalReturning) exhaustPhysicalPlans(prop *property.PhysicalProperty) ([]PhysicalPlan, bool) {
+	if !prop.IsEmpty() {
+		return nil, true
+	}
+
+	returning := PhysicalReturning{}.Init(p.ctx, p.stats, p.blockOffset, &property.PhysicalProperty{ExpectedCnt: 2})
+	return []PhysicalPlan{returning}, true
+}

--- a/planner/core/initialize.go
+++ b/planner/core/initialize.go
@@ -483,6 +483,18 @@ func (p PointGetPlan) Init(ctx sessionctx.Context, stats *property.StatsInfo, of
 	return &p
 }
 
+func (p LogicalReturning) Init(ctx sessionctx.Context, offset int) *LogicalReturning {
+	p.baseLogicalPlan = newBaseLogicalPlan(ctx, plancodec.TypeReturning, &p, offset)
+	return &p
+}
+
+func (p PhysicalReturning) Init(ctx sessionctx.Context, stats *property.StatsInfo, offset int, props ...*property.PhysicalProperty) *PhysicalReturning {
+	p.basePhysicalPlan = newBasePhysicalPlan(ctx, plancodec.TypeReturning, &p, offset)
+	p.childrenReqProps = props
+	p.stats = stats
+	return &p
+}
+
 func flattenTreePlan(plan PhysicalPlan, plans []PhysicalPlan) []PhysicalPlan {
 	plans = append(plans, plan)
 	for _, child := range plan.Children() {

--- a/planner/core/logical_plans.go
+++ b/planner/core/logical_plans.go
@@ -1260,4 +1260,11 @@ func (p *LogicalShowDDLJobs) SetParamType(paramExprs *[]ast.ParamMarkerExpr) (er
 // LogicalReturning represents returning plan.
 type LogicalReturning struct {
 	baseLogicalPlan
+
+	Offset uint64
+	Count  uint64
+}
+
+func (p *LogicalReturning) SetParamType(paramExprs *[]ast.ParamMarkerExpr) (err error) {
+	return err
 }

--- a/planner/core/logical_plans.go
+++ b/planner/core/logical_plans.go
@@ -1256,3 +1256,8 @@ type LogicalShowDDLJobs struct {
 func (p *LogicalShowDDLJobs) SetParamType(paramExprs *[]ast.ParamMarkerExpr) (err error) {
 	return err
 }
+
+// LogicalReturning represents returning plan.
+type LogicalReturning struct {
+	baseLogicalPlan
+}

--- a/planner/core/physical_plans.go
+++ b/planner/core/physical_plans.go
@@ -27,8 +27,9 @@
 package core
 
 import (
-	driver "github.com/pingcap/tidb/types/parser_driver"
 	"unsafe"
+
+	driver "github.com/pingcap/tidb/types/parser_driver"
 
 	"github.com/DigitalChinaOpenSource/DCParser/ast"
 	"github.com/DigitalChinaOpenSource/DCParser/model"
@@ -74,6 +75,7 @@ var (
 	_ PhysicalPlan = &PhysicalShuffle{}
 	_ PhysicalPlan = &PhysicalShuffleDataSourceStub{}
 	_ PhysicalPlan = &BatchPointGetPlan{}
+	_ PhysicalPlan = &PhysicalReturning{}
 )
 
 // PhysicalTableReader is the table reader in tidb.
@@ -1025,4 +1027,13 @@ func CheckParamFullySeted(paramExprs *[]ast.ParamMarkerExpr) bool {
 		}
 	}
 	return true
+}
+
+// PhysicalReturning presents a returning plan
+type PhysicalReturning struct {
+	basePhysicalPlan
+}
+
+func (p *PhysicalReturning) SetParamType(paramExprs *[]ast.ParamMarkerExpr) (err error) {
+	return nil
 }

--- a/server/conn.go
+++ b/server/conn.go
@@ -54,9 +54,6 @@ import (
 	"crypto/x509"
 	"encoding/binary"
 	"fmt"
-	"github.com/jackc/pgio"
-	"github.com/jackc/pgproto3/v2"
-	"github.com/jackc/pgtype"
 	"io"
 	"io/ioutil"
 	"net"
@@ -70,7 +67,11 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/DigitalChinaOpenSource/DCParser"
+	"github.com/jackc/pgio"
+	"github.com/jackc/pgproto3/v2"
+	"github.com/jackc/pgtype"
+
+	parser "github.com/DigitalChinaOpenSource/DCParser"
 	"github.com/DigitalChinaOpenSource/DCParser/ast"
 	"github.com/DigitalChinaOpenSource/DCParser/auth"
 	"github.com/DigitalChinaOpenSource/DCParser/mysql"
@@ -1590,7 +1591,11 @@ func (cc *clientConn) writeResultset(ctx context.Context, rs ResultSet, resultFo
 		//err = cc.writeChunksWithFetchSize(ctx, rs, serverStatus, fetchSize)
 		err = nil
 	} else {
-		err = cc.writeChunks(ctx, rs, serverStatus, resultFormat)
+		if rs.IsReturning() {
+			err = cc.writeReturningChunks(ctx, rs)
+		} else {
+			err = cc.writeChunks(ctx, rs, serverStatus, resultFormat)
+		}
 	}
 
 	return err
@@ -1610,6 +1615,53 @@ func (cc *clientConn) writeColumnInfo(columns []*ColumnInfo, serverStatus uint16
 		}
 	}
 	return cc.writeEOF(serverStatus)
+}
+
+func (cc *clientConn) writeReturningChunks(ctx context.Context, rs ResultSet) error {
+	data := cc.alloc.AllocWithLen(0, 1024)
+
+	var stmtDetail *execdetails.StmtExecDetails
+	stmtDetailRaw := ctx.Value(execdetails.StmtExecDetailKey)
+	if stmtDetailRaw != nil {
+		stmtDetail = stmtDetailRaw.(*execdetails.StmtExecDetails)
+	}
+
+	rows := rs.GetFetchedRows()
+	if len(rows) == 0 {
+		return nil
+	}
+	start := time.Now()
+	reg := trace.StartRegion(ctx, "WriteReturningClientConn")
+
+	columns := rs.Columns()
+	err := cc.WriteRowDescription(columns)
+	if err != nil {
+		return err
+	}
+
+	rowCount := 1
+	data = append(data, 'D')
+	data = pgio.AppendInt32(data, -1)
+	for i := 0; i < rowCount; i++ {
+		data = data[0:5]
+
+		data, err := dumpTextRowData(data, rs.Columns(), rows[i])
+
+		if err != nil {
+			return err
+		}
+
+		pgio.SetInt32(data[1:], int32(len(data[1:])))
+		if err = cc.WriteData(data); err != nil {
+			return err
+		}
+	}
+	if stmtDetail != nil {
+		stmtDetail.WriteSQLRespDuration += time.Since(start)
+	}
+	reg.End()
+
+	return cc.writeCommandComplete()
 }
 
 // writeChunks writes data from a Chunk, which filled data by a ResultSet, into a connection.

--- a/server/conn.go
+++ b/server/conn.go
@@ -1639,7 +1639,7 @@ func (cc *clientConn) writeReturningChunks(ctx context.Context, rs ResultSet) er
 		return err
 	}
 
-	rowCount := 1
+	rowCount := len(rows)
 	data = append(data, 'D')
 	data = pgio.AppendInt32(data, -1)
 	for i := 0; i < rowCount; i++ {

--- a/server/driver.go
+++ b/server/driver.go
@@ -184,6 +184,7 @@ type ResultSet interface {
 	GetFetchedRows() []chunk.Row
 	Close() error
 	IsPrepareStmt() bool
+	IsReturning() bool
 }
 
 // fetchNotifier represents notifier will be called in COM_FETCH.

--- a/server/driver_tidb.go
+++ b/server/driver_tidb.go
@@ -442,6 +442,12 @@ func (trs *tidbResultSet) IsPrepareStmt() bool {
 	return false
 }
 
+func (trs *tidbResultSet) IsReturning() bool {
+	rows := trs.recordSet.Rows()
+
+	return len(rows) > 0
+}
+
 func (trs *tidbResultSet) NewChunk() *chunk.Chunk {
 	return trs.recordSet.NewChunk()
 }
@@ -455,7 +461,11 @@ func (trs *tidbResultSet) StoreFetchedRows(rows []chunk.Row) {
 }
 
 func (trs *tidbResultSet) GetFetchedRows() []chunk.Row {
-	if trs.rows == nil {
+	rows := trs.recordSet.Rows()
+
+	if len(rows) > 0 {
+		trs.rows = rows
+	} else if trs.rows == nil {
 		trs.rows = make([]chunk.Row, 0, 1024)
 	}
 	return trs.rows

--- a/session/session.go
+++ b/session/session.go
@@ -43,7 +43,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/DigitalChinaOpenSource/DCParser"
+	parser "github.com/DigitalChinaOpenSource/DCParser"
 	"github.com/DigitalChinaOpenSource/DCParser/ast"
 	"github.com/DigitalChinaOpenSource/DCParser/auth"
 	"github.com/DigitalChinaOpenSource/DCParser/charset"

--- a/statistics/statistics_test.go
+++ b/statistics/statistics_test.go
@@ -61,6 +61,10 @@ func (r *recordSet) Fields() []*ast.ResultField {
 	return r.fields
 }
 
+func (r *recordSet) Rows() []chunk.Row {
+	return nil
+}
+
 func (r *recordSet) setFields(tps ...uint8) {
 	r.fields = make([]*ast.ResultField, len(tps))
 	for i := 0; i < len(tps); i++ {

--- a/store/mockstore/mocktikv/analyze.go
+++ b/store/mockstore/mocktikv/analyze.go
@@ -241,6 +241,10 @@ func (e *analyzeColumnsExec) Fields() []*ast.ResultField {
 	return e.fields
 }
 
+func (e *analyzeColumnsExec) Rows() []chunk.Row {
+	return nil
+}
+
 func (e *analyzeColumnsExec) getNext(ctx context.Context) ([]types.Datum, error) {
 	values, err := e.tblExec.Next(ctx)
 	if err != nil {

--- a/util/dc/dc_util
+++ b/util/dc/dc_util
@@ -1,0 +1,237 @@
+// Copyright 2021 Digital China Group Co.,Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dc
+
+import (
+	"context"
+	"runtime"
+	"runtime/trace"
+	"strings"
+	"time"
+
+	"github.com/DigitalChinaOpenSource/DCParser/mysql"
+	"github.com/DigitalChinaOpenSource/DCParser/terror"
+	"github.com/jackc/pgio"
+	"github.com/jackc/pgproto3"
+	"github.com/jackc/pgtype"
+	"github.com/pingcap/tidb/server"
+	"github.com/pingcap/tidb/util/execdetails"
+	"github.com/pingcap/tidb/util/logutil"
+	"github.com/pingcap/tidb/util/memory"
+	"github.com/pkg/errors"
+	"go.uber.org/zap"
+)
+
+// writeResultset writes data into a resultset and uses rs.Next to get row data back.
+// If resultFormat is nil, the data would be encoded in Text format.
+// If resultFormat just one value, the data would be encoded in Text(0) or Binary(1) format
+// If resultFormat have many values, each column would be encoded in Text(0) or Binary(1) format.
+// serverStatus, a flag bit represents server information.
+// fetchSize, the desired number of rows to be fetched each time when client uses cursor.
+func WriteResultset(ctx context.Context, rs server.ResultSet, resultFormat []int16, serverStatus uint16, fetchSize int) (runErr error) {
+	defer func() {
+		// close ResultSet when cursor doesn't exist
+		r := recover()
+		if r == nil {
+			return
+		}
+		if str, ok := r.(string); !ok || !strings.HasPrefix(str, memory.PanicMemoryExceed) {
+			panic(r)
+		}
+		// TODO(jianzhang.zj: add metrics here)
+		runErr = errors.Errorf("%v", r)
+		buf := make([]byte, 4096)
+		stackSize := runtime.Stack(buf, false)
+		buf = buf[:stackSize]
+		logutil.Logger(ctx).Error("write query result panic", zap.Stringer("lastSQL", getLastStmtInConn{cc}), zap.String("stack", string(buf)))
+	}()
+	var err error
+	if mysql.HasCursorExistsFlag(serverStatus) {
+		// todo writeChunksWithFetchSize
+		//err = cc.writeChunksWithFetchSize(ctx, rs, serverStatus, fetchSize)
+		err = nil
+	} else {
+		err = writeChunks(ctx, rs, serverStatus, resultFormat)
+	}
+
+	return err
+}
+
+func writeChunks(ctx context.Context, rs server.ResultSet, serverStatus uint16, rf []int16) error {
+	data := cc.alloc.AllocWithLen(0, 1024)
+	req := rs.NewChunk()
+
+	// 当为预处理查询执行时，在执行完成后不需要返回 RowDescription
+	gotColumnInfo := rs.IsPrepareStmt()
+
+	var stmtDetail *execdetails.StmtExecDetails
+	stmtDetailRaw := ctx.Value(execdetails.StmtExecDetailKey)
+	if stmtDetailRaw != nil {
+		stmtDetail = stmtDetailRaw.(*execdetails.StmtExecDetails)
+	}
+	for {
+		// Here server.tidbResultSet implements Next method.
+		err := rs.Next(ctx, req)
+		if err != nil {
+			return err
+		}
+		if !gotColumnInfo {
+			// We need to call Next before we get columns.
+			// Otherwise, we will get incorrect columns info.
+			columns := rs.Columns()
+			// err = cc.writeColumnInfo(columns, serverStatus)
+			err = cc.WriteRowDescription(columns)
+			if err != nil {
+				return err
+			}
+			gotColumnInfo = true
+		}
+		rowCount := req.NumRows()
+		if rowCount == 0 {
+			break
+		}
+		start := time.Now()
+		reg := trace.StartRegion(ctx, "WriteClientConn")
+
+		// rowdata : 'D' + len(msg) + len(columns) + for(len(val) + val)
+		data = append(data, 'D')
+		data = pgio.AppendInt32(data, -1)
+		for i := 0; i < rowCount; i++ {
+			data = data[0:5]
+			if len(rf) > 0 {
+				data, err = dumpRowData(data, rs.Columns(), req.GetRow(i), rf)
+			} else {
+				data, err = dumpTextRowData(data, rs.Columns(), req.GetRow(i))
+			}
+			if err != nil {
+				return err
+			}
+
+			pgio.SetInt32(data[1:], int32(len(data[1:])))
+			if err = cc.WriteData(data); err != nil {
+				return err
+			}
+		}
+		if stmtDetail != nil {
+			stmtDetail.WriteSQLRespDuration += time.Since(start)
+		}
+		reg.End()
+	}
+
+	return cc.writeCommandComplete()
+}
+
+func WriteRowDescription(columns []*server.ColumnInfo) error {
+	if len(columns) <= 0 || columns == nil {
+		return errors.New("columnInfos is empty")
+	}
+	rowDescription := convertColumnInfoToRowDescription(columns)
+
+	return WriteData(rowDescription.Encode(nil))
+}
+
+func writeRowDescription(columns []*server.ColumnInfo) error {
+	if len(columns) <= 0 || columns == nil {
+		return errors.New("columnInfos is empty")
+	}
+	rowDescription := convertColumnInfoToRowDescription(columns)
+
+	return WriteData(rowDescription.Encode(nil))
+}
+
+func convertColumnInfoToRowDescription(columns []*server.ColumnInfo) pgproto3.RowDescription {
+	// todo 完善两者字段结构信息的转换
+
+	if strings.Contains(columns[0].Name, "(") {
+		columns[0].Name = strings.Split(columns[0].Name, "(")[0]
+	}
+	fieldDescriptions := make([]pgproto3.FieldDescription, len(columns))
+	for index := range columns {
+		fieldDescriptions[index] = pgproto3.FieldDescription{
+			Name:                 []byte(columns[index].Name),
+			TableOID:             0,
+			TableAttributeNumber: 0,
+			DataTypeOID:          convertMySQLDataTypeToPgSQLDataType(columns[index].Type),
+			DataTypeSize:         int16(columns[index].ColumnLength),
+			TypeModifier:         0,
+			Format:               0,
+		}
+	}
+
+	return pgproto3.RowDescription{Fields: fieldDescriptions}
+}
+
+func convertMySQLDataTypeToPgSQLDataType(mysqlType uint8) uint32 {
+	// todo 完善 mysql 和 pgsql 对应的数据类型
+
+	switch mysqlType {
+	case mysql.TypeUnspecified:
+		return pgtype.UnknownOID
+	case mysql.TypeTiny, mysql.TypeShort:
+		return pgtype.Int2OID
+	case mysql.TypeLong, mysql.TypeInt24:
+		return pgtype.Int4OID
+	case mysql.TypeFloat:
+		return pgtype.Float4OID
+	case mysql.TypeDouble:
+		return pgtype.Float8OID
+	case mysql.TypeNull: //未找到对应类型
+		return pgtype.UnknownOID
+	case mysql.TypeTimestamp:
+		return pgtype.TimestampOID
+	case mysql.TypeLonglong:
+		return pgtype.Int8OID
+	case mysql.TypeDate:
+		return pgtype.DateOID
+	case mysql.TypeDuration:
+		return pgtype.TimeOID //与Time并不完全想对应
+	case mysql.TypeDatetime:
+		return pgtype.TimestampOID
+	case mysql.TypeYear:
+		return pgtype.UnknownOID //未找到对应类型
+	case mysql.TypeNewDate:
+		return pgtype.DateOID
+	case mysql.TypeVarchar:
+		return pgtype.VarcharOID
+	case mysql.TypeBit:
+		return pgtype.BitOID
+	case mysql.TypeJSON:
+		return pgtype.JSONOID
+	case mysql.TypeNewDecimal:
+		return pgtype.NumericOID
+	case mysql.TypeEnum:
+		return pgtype.UnknownOID //未找到对应类型dumpLengthEncodedStringByEndian
+	case mysql.TypeSet:
+		return pgtype.UnknownOID //未找到对应类型
+	case mysql.TypeTinyBlob, mysql.TypeMediumBlob, mysql.TypeLongBlob, mysql.TypeBlob:
+		return pgtype.ByteaOID
+	case mysql.TypeVarString, mysql.TypeString:
+		return pgtype.TextOID
+	case mysql.TypeGeometry:
+		return pgtype.UnknownOID //未找到对应类型
+	default:
+		return pgtype.UnknownOID
+	}
+}
+
+func WriteData(data []byte) error {
+	if n, err := cc.pkt.bufWriter.Write(data); err != nil {
+		terror.Log(errors.Trace(err))
+		return errors.Trace(mysql.ErrBadConn)
+	} else if n != len(data) {
+		return errors.Trace(mysql.ErrBadConn)
+	} else {
+		return nil
+	}
+}

--- a/util/plancodec/id.go
+++ b/util/plancodec/id.go
@@ -118,6 +118,8 @@ const (
 	TypeIndexFullScan = "IndexFullScan"
 	// TypeIndexRangeScan is the type of IndexRangeScan.
 	TypeIndexRangeScan = "IndexRangeScan"
+	//TypeReturning is the type of Returing
+	TypeReturning = "Returning"
 )
 
 // plan id.
@@ -169,6 +171,7 @@ const (
 	typeTableRowIDScan        int = 45
 	typeIndexFullScan         int = 46
 	typeIndexRangeScan        int = 47
+	typeReturning             int = 48
 )
 
 // TypeStringToPhysicalID converts the plan type string to plan id.
@@ -268,6 +271,8 @@ func TypeStringToPhysicalID(tp string) int {
 		return typeIndexFullScan
 	case TypeIndexRangeScan:
 		return typeIndexRangeScan
+	case TypeReturning:
+		return typeReturning
 	}
 	// Should never reach here.
 	return 0
@@ -368,6 +373,8 @@ func PhysicalIDToTypeString(id int) string {
 		return TypeIndexFullScan
 	case typeIndexRangeScan:
 		return TypeIndexRangeScan
+	case typeReturning:
+		return TypeReturning
 	}
 
 	// Should never reach here.

--- a/util/sqlexec/restricted_sql_executor.go
+++ b/util/sqlexec/restricted_sql_executor.go
@@ -92,6 +92,9 @@ type RecordSet interface {
 	// Fields gets result fields.
 	Fields() []*ast.ResultField
 
+	// Returning rows
+	Rows() []chunk.Row
+
 	// Next reads records into chunk.
 	Next(ctx context.Context, req *chunk.Chunk) error
 


### PR DESCRIPTION
### What problem does this PR solve?
Add returning keyword plan and executor for supporting PG compliant DML

Issue Number: #40

Problem Summary:

### What is changed and how it works?

What's Changed:
1. update DC parser version to parse returning keyword
2. support result set after deletion
3. add returning plan and executor

Side effects

- Performance regression
    - Consumes more MEM
